### PR TITLE
Add user registration and role seeding

### DIFF
--- a/Dekofar.HyperConnect.Application/Interfaces/ITokenService.cs
+++ b/Dekofar.HyperConnect.Application/Interfaces/ITokenService.cs
@@ -8,6 +8,6 @@ namespace Dekofar.HyperConnect.Application.Interfaces
 {
     public interface ITokenService
     {
-        string GenerateToken(string userId, string email, string role);
+        string GenerateToken(string userId, string email, IEnumerable<string> roles);
     }
 }

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -10,7 +10,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Dekofar.HyperConnect.Infrastructure.Persistence
 {
-    public class ApplicationDbContext : IdentityDbContext<AppUser, IdentityRole<Guid>, Guid>, IApplicationDbContext
+    public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>, IApplicationDbContext
     {
         public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
             : base(options) { }

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -2,6 +2,7 @@
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Application.Interfaces;
 using Dekofar.HyperConnect.Domain.Entities;
+using Dekofar.Domain.Entities;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Dekofar.HyperConnect.Infrastructure.Services;
 using Dekofar.HyperConnect.Integrations.NetGsm.Interfaces;
@@ -30,8 +31,8 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             // 📦 IApplicationDbContext implementasyonu
             services.AddScoped<IApplicationDbContext>(provider => provider.GetRequiredService<ApplicationDbContext>());
 
-            // 🔐 Identity (AppUser + Role<Guid>)
-            services.AddIdentity<AppUser, IdentityRole<Guid>>(options =>
+            // 🔐 Identity (ApplicationUser + Role<Guid>)
+            services.AddIdentity<ApplicationUser, IdentityRole<Guid>>(options =>
             {
                 options.Password.RequireDigit = true;
                 options.Password.RequiredLength = 6;

--- a/Dekofar.HyperConnect.Infrastructure/Services/RoleSeeder.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/RoleSeeder.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Identity;
+using System;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    public static class RoleSeeder
+    {
+        public static async Task SeedAsync(RoleManager<IdentityRole<Guid>> roleManager)
+        {
+            string[] roles = new[] { "Admin", "User", "Support" };
+
+            foreach (var role in roles)
+            {
+                if (!await roleManager.RoleExistsAsync(role))
+                {
+                    await roleManager.CreateAsync(new IdentityRole<Guid>(role));
+                }
+            }
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Support/SupportTicketController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Support/SupportTicketController.cs
@@ -38,6 +38,7 @@ namespace Dekofar.HyperConnect.API.Controllers.Support
         /// Tüm destek taleplerini getirir.
         /// </summary>
         [HttpGet]
+        [Authorize(Roles = "Admin,Support")]
         public async Task<IActionResult> GetAll()
         {
             var result = await _mediator.Send(new GetAllSupportTicketsQuery());
@@ -48,6 +49,7 @@ namespace Dekofar.HyperConnect.API.Controllers.Support
         /// Belirli destek talebini detaylı getirir.
         /// </summary>
         [HttpGet("{id}")]
+        [Authorize(Roles = "Admin,Support")]
         public async Task<IActionResult> GetById(int id)
         {
             var result = await _mediator.Send(new GetSupportTicketByIdQuery(id));
@@ -59,6 +61,7 @@ namespace Dekofar.HyperConnect.API.Controllers.Support
         /// Destek talebine not ekler.
         /// </summary>
         [HttpPost("{id}/note")]
+        [Authorize(Roles = "Admin,Support")]
         public async Task<IActionResult> AddNote(int id, [FromBody] AddTicketNoteCommand command)
         {
             command.TicketId = id;
@@ -70,6 +73,7 @@ namespace Dekofar.HyperConnect.API.Controllers.Support
         /// Talebi belirli bir kullanıcıya atar.
         /// </summary>
         [HttpPost("{id}/assign")]
+        [Authorize(Roles = "Admin,Support")]
         public async Task<IActionResult> Assign(int id, [FromBody] AssignSupportTicketCommand command)
         {
             if (id != command.TicketId) return BadRequest("ID uyuşmuyor.");
@@ -81,6 +85,7 @@ namespace Dekofar.HyperConnect.API.Controllers.Support
         /// Talep durumunu günceller.
         /// </summary>
         [HttpPost("{id}/status")]
+        [Authorize(Roles = "Admin,Support")]
         public async Task<IActionResult> UpdateStatus(int id, [FromBody] UpdateTicketStatusCommand command)
         {
             if (id != command.TicketId) return BadRequest("ID uyuşmuyor.");

--- a/dekofar-hyperconnect-api/Controllers/UsersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/UsersController.cs
@@ -1,4 +1,4 @@
-﻿using Dekofar.HyperConnect.Domain.Entities;
+using Dekofar.Domain.Entities;
 using Dekofar.HyperConnect.Domain.DTOs;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
@@ -15,9 +15,9 @@ namespace Dekofar.API.Controllers
     //[Authorize(Roles = "Admin")] // isteğe bağlı aktif edebilirsin
     public class UsersController : ControllerBase
     {
-        private readonly UserManager<AppUser> _userManager;
+        private readonly UserManager<ApplicationUser> _userManager;
 
-        public UsersController(UserManager<AppUser> userManager)
+        public UsersController(UserManager<ApplicationUser> userManager)
         {
             _userManager = userManager;
         }

--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -14,6 +14,7 @@ using Dekofar.HyperConnect.Integrations.NetGsm.Services;
 using Dekofar.HyperConnect.Integrations.Shopify.Interfaces;
 using Dekofar.HyperConnect.Integrations.Shopify.Services;
 using Dekofar.HyperConnect.Application; // Application servis kayıtları
+using Dekofar.HyperConnect.Infrastructure.Services;
 using MediatR;
 using Dekofar.HyperConnect.Infrastructure.ServiceRegistration;
 
@@ -109,15 +110,7 @@ app.MapControllers();
 using (var scope = app.Services.CreateScope())
 {
     var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
-    string[] roles = new[] { "Admin", "PERSONEL", "DEPO", "IADE", "MUSTERI_TEM" };
-
-    foreach (var role in roles)
-    {
-        if (!await roleManager.RoleExistsAsync(role))
-        {
-            await roleManager.CreateAsync(new IdentityRole<Guid>(role));
-        }
-    }
+    await RoleSeeder.SeedAsync(roleManager);
 }
 
 app.Run();


### PR DESCRIPTION
## Summary
- implement new register endpoint using `ApplicationUser`
- include user roles in JWT tokens
- seed default roles on startup
- restrict support ticket actions to Admin or Support roles
- refactor to use `ApplicationUser` identity class

## Testing
- `dotnet build dekofar-hyperconnect-api.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688caf5fec9c8326b9f7d9682e72c07a