### PR TITLE
Add default data seeding for roles, admin user, and support ticket

### DIFF
--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -103,6 +103,6 @@ app.UseAuthorization();
 app.MapControllers();
 
 // 🚀 Seed default roles and admin user
-await SeedData.SeedDefaultRolesAndAdminAsync(app.Services);
+await SeedData.SeedDefaultsAsync(app.Services);
 
 app.Run();


### PR DESCRIPTION
## Summary
- add `SeedData.SeedDefaultsAsync` to create default roles and admin user and to seed a test support ticket
- invoke seeding method on application startup

## Testing
- `dotnet build dekofar-hyperconnect-api.sln`
- `dotnet test dekofar-hyperconnect-api.sln` *(no tests found, projects up-to-date)*

------
https://chatgpt.com/codex/tasks/task_e_688db196ef2c8326b5146baa8f7a4a5f