### PR TITLE
Add manual order entity and creation endpoint

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,6 +1,7 @@
 ﻿using Dekofar.Domain.Entities;
 using Dekofar.HyperConnect.Domain.Entities.support;
 using Dekofar.HyperConnect.Domain.Entities.Support;
+using Dekofar.HyperConnect.Domain.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System.Threading;
@@ -16,6 +17,9 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<TicketLog> TicketLogs { get; }
         DbSet<TicketAttachment> TicketAttachments { get; }
         DbSet<SupportTicketHistory> SupportTicketHistories { get; }
+
+        DbSet<ManualOrder> ManualOrders { get; }
+        DbSet<ManualOrderItem> ManualOrderItems { get; }
 
         // Bildirim sistemi
         DbSet<AppNotification> AppNotifications { get; }

--- a/Dekofar.HyperConnect.Application/ManualOrders/Commands/CreateManualOrderCommand.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/Commands/CreateManualOrderCommand.cs
@@ -1,0 +1,44 @@
+using MediatR;
+using System.ComponentModel.DataAnnotations;
+
+namespace Dekofar.HyperConnect.Application.ManualOrders.Commands
+{
+    public class CreateManualOrderCommand : IRequest<Guid>
+    {
+        [Required]
+        public string CustomerName { get; set; } = default!;
+        [Required]
+        public string CustomerSurname { get; set; } = default!;
+        [Required]
+        public string Phone { get; set; } = default!;
+        [EmailAddress]
+        public string? Email { get; set; }
+        [Required]
+        public string Address { get; set; } = default!;
+        [Required]
+        public string City { get; set; } = default!;
+        [Required]
+        public string District { get; set; } = default!;
+        [Required]
+        public string PaymentType { get; set; } = default!;
+        public string? OrderNote { get; set; }
+        public string? DiscountName { get; set; }
+        public string? DiscountType { get; set; }
+        public decimal DiscountValue { get; set; }
+
+        [MinLength(1)]
+        public List<CreateManualOrderItemDto> Items { get; set; } = new();
+    }
+
+    public class CreateManualOrderItemDto
+    {
+        [Required]
+        public string ProductId { get; set; } = default!;
+        [Required]
+        public string ProductName { get; set; } = default!;
+        [Range(1, int.MaxValue)]
+        public int Quantity { get; set; }
+        public decimal Price { get; set; }
+    }
+}
+

--- a/Dekofar.HyperConnect.Application/ManualOrders/DTOs/ManualOrderDto.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/DTOs/ManualOrderDto.cs
@@ -1,0 +1,39 @@
+using Dekofar.HyperConnect.Domain.Entities;
+
+namespace Dekofar.HyperConnect.Application.ManualOrders.DTOs
+{
+    public class ManualOrderDto
+    {
+        public Guid Id { get; set; }
+        public string CustomerName { get; set; } = default!;
+        public string CustomerSurname { get; set; } = default!;
+        public string Phone { get; set; } = default!;
+        public string? Email { get; set; }
+        public string Address { get; set; } = default!;
+        public string City { get; set; } = default!;
+        public string District { get; set; } = default!;
+        public string PaymentType { get; set; } = default!;
+        public string? OrderNote { get; set; }
+        public Guid CreatedByUserId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public ManualOrderStatus Status { get; set; }
+        public decimal TotalAmount { get; set; }
+        public string? DiscountName { get; set; }
+        public string? DiscountType { get; set; }
+        public decimal DiscountValue { get; set; }
+        public decimal BonusAmount { get; set; }
+
+        public List<ManualOrderItemDto> Items { get; set; } = new();
+    }
+
+    public class ManualOrderItemDto
+    {
+        public Guid Id { get; set; }
+        public string ProductId { get; set; } = default!;
+        public string ProductName { get; set; } = default!;
+        public int Quantity { get; set; }
+        public decimal Price { get; set; }
+        public decimal Total { get; set; }
+    }
+}
+

--- a/Dekofar.HyperConnect.Application/ManualOrders/Handlers/CreateManualOrderHandler.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/Handlers/CreateManualOrderHandler.cs
@@ -1,0 +1,81 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.ManualOrders.Commands;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using System;
+using System.Linq;
+
+namespace Dekofar.HyperConnect.Application.ManualOrders.Handlers
+{
+    public class CreateManualOrderHandler : IRequestHandler<CreateManualOrderCommand, Guid>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public CreateManualOrderHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<Guid> Handle(CreateManualOrderCommand request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var order = new ManualOrder
+            {
+                CustomerName = request.CustomerName,
+                CustomerSurname = request.CustomerSurname,
+                Phone = request.Phone,
+                Email = request.Email,
+                Address = request.Address,
+                City = request.City,
+                District = request.District,
+                PaymentType = request.PaymentType,
+                OrderNote = request.OrderNote,
+                CreatedByUserId = _currentUser.UserId.Value,
+                CreatedAt = DateTime.UtcNow,
+                Status = ManualOrderStatus.Pending,
+                DiscountName = request.DiscountName,
+                DiscountType = request.DiscountType,
+                DiscountValue = request.DiscountValue
+            };
+
+            foreach (var item in request.Items)
+            {
+                order.Items.Add(new ManualOrderItem
+                {
+                    ProductId = item.ProductId,
+                    ProductName = item.ProductName,
+                    Quantity = item.Quantity,
+                    Price = item.Price,
+                    Total = item.Price * item.Quantity
+                });
+            }
+
+            var subTotal = order.Items.Sum(i => i.Total);
+            decimal discount = 0m;
+            if (!string.IsNullOrEmpty(request.DiscountType))
+            {
+                if (request.DiscountType.Equals("Percentage", StringComparison.OrdinalIgnoreCase))
+                {
+                    discount = subTotal * request.DiscountValue / 100m;
+                }
+                else
+                {
+                    discount = request.DiscountValue;
+                }
+            }
+
+            order.TotalAmount = subTotal - discount;
+            order.BonusAmount = order.TotalAmount * 0.1m; // simple commission calculation
+
+            await _context.ManualOrders.AddAsync(order, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            return order.Id;
+        }
+    }
+}
+

--- a/Dekofar.HyperConnect.Domain/Entities/ManualOrder.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ManualOrder.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class ManualOrder
+    {
+        public Guid Id { get; set; }
+        public string CustomerName { get; set; } = default!;
+        public string CustomerSurname { get; set; } = default!;
+        public string Phone { get; set; } = default!;
+        public string? Email { get; set; }
+        public string Address { get; set; } = default!;
+        public string City { get; set; } = default!;
+        public string District { get; set; } = default!;
+        public string PaymentType { get; set; } = default!;
+        public string? OrderNote { get; set; }
+        public Guid CreatedByUserId { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public ManualOrderStatus Status { get; set; } = ManualOrderStatus.Pending;
+        public decimal TotalAmount { get; set; }
+        public string? DiscountName { get; set; }
+        public string? DiscountType { get; set; }
+        public decimal DiscountValue { get; set; }
+        public decimal BonusAmount { get; set; }
+
+        public ICollection<ManualOrderItem> Items { get; set; } = new List<ManualOrderItem>();
+    }
+
+    public enum ManualOrderStatus
+    {
+        Pending = 0,
+        Confirmed = 1,
+        Delivered = 2,
+        Cancelled = 3
+    }
+}
+

--- a/Dekofar.HyperConnect.Domain/Entities/ManualOrderItem.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ManualOrderItem.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class ManualOrderItem
+    {
+        public Guid Id { get; set; }
+        public Guid ManualOrderId { get; set; }
+        public string ProductId { get; set; } = default!;
+        public string ProductName { get; set; } = default!;
+        public int Quantity { get; set; }
+        public decimal Price { get; set; }
+        public decimal Total { get; set; }
+
+        public ManualOrder? ManualOrder { get; set; }
+    }
+}
+

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -27,6 +27,8 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
 
         public DbSet<Tag> Tags { get; set; }
         public DbSet<OrderTag> OrderTags => Set<OrderTag>();
+        public DbSet<ManualOrder> ManualOrders => Set<ManualOrder>();
+        public DbSet<ManualOrderItem> ManualOrderItems => Set<ManualOrderItem>();
 
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
@@ -138,6 +140,45 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                       .WithMany(t => t.History)
                       .HasForeignKey(h => h.TicketId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            // ManualOrder
+            builder.Entity<ManualOrder>(entity =>
+            {
+                entity.ToTable("ManualOrders");
+                entity.HasKey(e => e.Id);
+
+                entity.Property(e => e.CustomerName).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.CustomerSurname).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.Phone).HasMaxLength(50);
+                entity.Property(e => e.Email).HasMaxLength(100);
+                entity.Property(e => e.Address).IsRequired().HasMaxLength(500);
+                entity.Property(e => e.City).HasMaxLength(100);
+                entity.Property(e => e.District).HasMaxLength(100);
+                entity.Property(e => e.PaymentType).HasMaxLength(50);
+                entity.Property(e => e.OrderNote).HasMaxLength(500);
+                entity.Property(e => e.TotalAmount).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.DiscountName).HasMaxLength(100);
+                entity.Property(e => e.DiscountType).HasMaxLength(50);
+                entity.Property(e => e.DiscountValue).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.BonusAmount).HasColumnType("decimal(18,2)");
+
+                entity.HasMany(e => e.Items)
+                      .WithOne(i => i.ManualOrder)
+                      .HasForeignKey(i => i.ManualOrderId)
+                      .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<ManualOrderItem>(entity =>
+            {
+                entity.ToTable("ManualOrderItems");
+                entity.HasKey(e => e.Id);
+
+                entity.Property(e => e.ProductId).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.ProductName).IsRequired().HasMaxLength(200);
+                entity.Property(e => e.Quantity).IsRequired();
+                entity.Property(e => e.Price).HasColumnType("decimal(18,2)");
+                entity.Property(e => e.Total).HasColumnType("decimal(18,2)");
             });
 
             // AppNotification

--- a/dekofar-hyperconnect-api/Controllers/ManualOrdersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/ManualOrdersController.cs
@@ -1,0 +1,29 @@
+using Dekofar.HyperConnect.Application.ManualOrders.Commands;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dekofar.HyperConnect.API.Controllers
+{
+    [ApiController]
+    [Route("api/manual-orders")]
+    public class ManualOrdersController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public ManualOrdersController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateManualOrderCommand command)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var id = await _mediator.Send(command);
+            return Ok(id);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add ManualOrder and ManualOrderItem domain models with status enum
- expose manual order sets in the EF context and configure relationships
- implement command/handler/DTO for creating manual orders
- add ManualOrdersController with POST endpoint returning created ID

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688dbb910ef4832699b7bfb8167cb140