### PR TITLE
Add user management with role assignment and avatar upload

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IFileStorageService.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IFileStorageService.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace Dekofar.HyperConnect.Application.Common.Interfaces
+{
+    public interface IFileStorageService
+    {
+        Task<string> SaveProfileImageAsync(IFormFile file, Guid userId);
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/AssignRolesToUserCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/AssignRolesToUserCommand.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    public class AssignRolesToUserCommand : IRequest<IdentityResult>
+    {
+        public Guid UserId { get; set; }
+        public List<string> Roles { get; set; } = new();
+    }
+
+    public class AssignRolesToUserCommandHandler : IRequestHandler<AssignRolesToUserCommand, IdentityResult>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly RoleManager<IdentityRole<Guid>> _roleManager;
+
+        public AssignRolesToUserCommandHandler(UserManager<ApplicationUser> userManager, RoleManager<IdentityRole<Guid>> roleManager)
+        {
+            _userManager = userManager;
+            _roleManager = roleManager;
+        }
+
+        public async Task<IdentityResult> Handle(AssignRolesToUserCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null)
+            {
+                return IdentityResult.Failed(new IdentityError { Description = "User not found." });
+            }
+
+            var currentRoles = await _userManager.GetRolesAsync(user);
+            var removeResult = await _userManager.RemoveFromRolesAsync(user, currentRoles);
+            if (!removeResult.Succeeded)
+            {
+                return removeResult;
+            }
+
+            foreach (var role in request.Roles)
+            {
+                if (!await _roleManager.RoleExistsAsync(role))
+                {
+                    var roleResult = await _roleManager.CreateAsync(new IdentityRole<Guid>(role));
+                    if (!roleResult.Succeeded)
+                    {
+                        return roleResult;
+                    }
+                }
+            }
+
+            return await _userManager.AddToRolesAsync(user, request.Roles);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/UploadProfileImageCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/UploadProfileImageCommand.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    public class UploadProfileImageCommand : IRequest<string>
+    {
+        public Guid UserId { get; set; }
+        public IFormFile File { get; set; } = default!;
+    }
+
+    public class UploadProfileImageCommandHandler : IRequestHandler<UploadProfileImageCommand, string>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IFileStorageService _fileStorageService;
+
+        public UploadProfileImageCommandHandler(UserManager<ApplicationUser> userManager, IFileStorageService fileStorageService)
+        {
+            _userManager = userManager;
+            _fileStorageService = fileStorageService;
+        }
+
+        public async Task<string> Handle(UploadProfileImageCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null)
+            {
+                throw new Exception("User not found");
+            }
+
+            var url = await _fileStorageService.SaveProfileImageAsync(request.File, request.UserId);
+            user.AvatarUrl = url;
+            await _userManager.UpdateAsync(user);
+            return url;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/DTOs/UserDto.cs
+++ b/Dekofar.HyperConnect.Application/Users/DTOs/UserDto.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dekofar.HyperConnect.Application.Users.DTOs
+{
+    public class UserDto
+    {
+        public Guid Id { get; set; }
+        public string? FullName { get; set; }
+        public string? Email { get; set; }
+        public string? UserName { get; set; }
+        public string? AvatarUrl { get; set; }
+        public List<string> Roles { get; set; } = new();
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Queries/GetAllUsersWithRolesQuery.cs
+++ b/Dekofar.HyperConnect.Application/Users/Queries/GetAllUsersWithRolesQuery.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Application.Users.DTOs;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.Users.Queries
+{
+    public record GetAllUsersWithRolesQuery : IRequest<List<UserDto>>;
+
+    public class GetAllUsersWithRolesQueryHandler : IRequestHandler<GetAllUsersWithRolesQuery, List<UserDto>>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public GetAllUsersWithRolesQueryHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<List<UserDto>> Handle(GetAllUsersWithRolesQuery request, CancellationToken cancellationToken)
+        {
+            var users = await _userManager.Users.ToListAsync(cancellationToken);
+            var result = new List<UserDto>();
+
+            foreach (var user in users)
+            {
+                var roles = await _userManager.GetRolesAsync(user);
+                result.Add(new UserDto
+                {
+                    Id = user.Id,
+                    FullName = user.FullName,
+                    Email = user.Email,
+                    UserName = user.UserName,
+                    AvatarUrl = user.AvatarUrl,
+                    Roles = roles.ToList()
+                });
+            }
+
+            return result;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -8,5 +8,10 @@ namespace Dekofar.Domain.Entities
         public string? FullName { get; set; }
         //public string? Role { get; set; }
 
+        /// <summary>
+        ///     URL or file path of the user's profile image.
+        /// </summary>
+        public string? AvatarUrl { get; set; }
+
     }
 }

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -72,6 +72,7 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             });
             services.AddHttpContextAccessor(); // gerekli
             services.AddScoped<ICurrentUserService, CurrentUserService>();
+            services.AddScoped<IFileStorageService, LocalFileStorageService>();
 
             // 📞 NetGSM servisleri
             services.AddScoped<INetGsmCallService, NetGsmCallService>();

--- a/Dekofar.HyperConnect.Infrastructure/Services/LocalFileStorageService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/LocalFileStorageService.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    public class LocalFileStorageService : IFileStorageService
+    {
+        public async Task<string> SaveProfileImageAsync(IFormFile file, Guid userId)
+        {
+            var uploadsRoot = Path.Combine(Directory.GetCurrentDirectory(), "uploads", "avatars");
+            Directory.CreateDirectory(uploadsRoot);
+
+            var filePath = Path.Combine(uploadsRoot, $"{userId}.jpg");
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            return $"/uploads/avatars/{userId}.jpg";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add AvatarUrl to ApplicationUser and expose user DTOs
- implement commands for assigning roles and uploading avatars
- wire up file storage and secure UsersController endpoints

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688dcf8846548326a6e8ce37397ed900