### PR TITLE
Add commission tracking for manual orders

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -14,6 +14,7 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<SupportCategoryRole> SupportCategoryRoles { get; }
         DbSet<ManualOrder> ManualOrders { get; }
         DbSet<ManualOrderItem> ManualOrderItems { get; }
+        DbSet<OrderCommission> OrderCommissions { get; }
         DbSet<Discount> Discounts { get; }
         DbSet<ApplicationUser> Users { get; }
         DbSet<IdentityUserRole<Guid>> UserRoles { get; }

--- a/Dekofar.HyperConnect.Application/ManualOrders/Handlers/CreateManualOrderHandler.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/Handlers/CreateManualOrderHandler.cs
@@ -1,5 +1,6 @@
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Application.ManualOrders.Commands;
+using Dekofar.HyperConnect.Application.OrderCommissions.Commands;
 using Dekofar.HyperConnect.Domain.Entities;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -12,11 +13,13 @@ namespace Dekofar.HyperConnect.Application.ManualOrders.Handlers
     {
         private readonly IApplicationDbContext _context;
         private readonly ICurrentUserService _currentUser;
+        private readonly IMediator _mediator;
 
-        public CreateManualOrderHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        public CreateManualOrderHandler(IApplicationDbContext context, ICurrentUserService currentUser, IMediator mediator)
         {
             _context = context;
             _currentUser = currentUser;
+            _mediator = mediator;
         }
 
         public async Task<Guid> Handle(CreateManualOrderCommand request, CancellationToken cancellationToken)
@@ -86,6 +89,8 @@ namespace Dekofar.HyperConnect.Application.ManualOrders.Handlers
 
             await _context.ManualOrders.AddAsync(order, cancellationToken);
             await _context.SaveChangesAsync(cancellationToken);
+
+            await _mediator.Send(new CreateOrderCommissionCommand(order.Id, order.CreatedByUserId, order.TotalAmount), cancellationToken);
 
             return order.Id;
         }

--- a/Dekofar.HyperConnect.Application/OrderCommissions/Commands/CreateOrderCommissionCommand.cs
+++ b/Dekofar.HyperConnect.Application/OrderCommissions/Commands/CreateOrderCommissionCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+using System;
+
+namespace Dekofar.HyperConnect.Application.OrderCommissions.Commands
+{
+    public record CreateOrderCommissionCommand(Guid OrderId, Guid UserId, decimal TotalAmount) : IRequest<Guid>;
+}

--- a/Dekofar.HyperConnect.Application/OrderCommissions/DTOs/OrderCommissionDto.cs
+++ b/Dekofar.HyperConnect.Application/OrderCommissions/DTOs/OrderCommissionDto.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.OrderCommissions.DTOs
+{
+    public class OrderCommissionDto
+    {
+        public Guid Id { get; set; }
+        public Guid OrderId { get; set; }
+        public Guid UserId { get; set; }
+        public decimal CommissionRate { get; set; }
+        public decimal EarnedAmount { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/OrderCommissions/Handlers/CreateOrderCommissionHandler.cs
+++ b/Dekofar.HyperConnect.Application/OrderCommissions/Handlers/CreateOrderCommissionHandler.cs
@@ -1,0 +1,39 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.OrderCommissions.Commands;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.OrderCommissions.Handlers
+{
+    public class CreateOrderCommissionHandler : IRequestHandler<CreateOrderCommissionCommand, Guid>
+    {
+        private readonly IApplicationDbContext _context;
+        private const decimal CommissionRate = 0.05m;
+
+        public CreateOrderCommissionHandler(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Guid> Handle(CreateOrderCommissionCommand request, CancellationToken cancellationToken)
+        {
+            var commission = new OrderCommission
+            {
+                Id = Guid.NewGuid(),
+                OrderId = request.OrderId,
+                UserId = request.UserId,
+                CommissionRate = CommissionRate,
+                EarnedAmount = request.TotalAmount * CommissionRate,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _context.OrderCommissions.AddAsync(commission, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            return commission.Id;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/OrderCommissions/Queries/GetCommissionsByUserQuery.cs
+++ b/Dekofar.HyperConnect.Application/OrderCommissions/Queries/GetCommissionsByUserQuery.cs
@@ -1,0 +1,70 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.OrderCommissions.DTOs;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.OrderCommissions.Queries
+{
+    public class GetCommissionsByUserQuery : IRequest<List<OrderCommissionDto>> { }
+
+    public class GetCommissionsByUserQueryHandler : IRequestHandler<GetCommissionsByUserQuery, List<OrderCommissionDto>>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public GetCommissionsByUserQueryHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<List<OrderCommissionDto>> Handle(GetCommissionsByUserQuery request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            return await _context.OrderCommissions
+                .Where(c => c.UserId == _currentUser.UserId)
+                .OrderByDescending(c => c.CreatedAt)
+                .Select(c => new OrderCommissionDto
+                {
+                    Id = c.Id,
+                    OrderId = c.OrderId,
+                    UserId = c.UserId,
+                    CommissionRate = c.CommissionRate,
+                    EarnedAmount = c.EarnedAmount,
+                    CreatedAt = c.CreatedAt
+                })
+                .ToListAsync(cancellationToken);
+        }
+    }
+
+    public class GetUserTotalCommissionQuery : IRequest<decimal> { }
+
+    public class GetUserTotalCommissionQueryHandler : IRequestHandler<GetUserTotalCommissionQuery, decimal>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public GetUserTotalCommissionQueryHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<decimal> Handle(GetUserTotalCommissionQuery request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            return await _context.OrderCommissions
+                .Where(c => c.UserId == _currentUser.UserId)
+                .SumAsync(c => c.EarnedAmount, cancellationToken);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/OrderCommission.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/OrderCommission.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class OrderCommission
+    {
+        public Guid Id { get; set; }
+        public Guid OrderId { get; set; }
+        public Guid UserId { get; set; }
+        public decimal CommissionRate { get; set; }
+        public decimal EarnedAmount { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -24,6 +24,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<OrderTag> OrderTags => Set<OrderTag>();
         public DbSet<ManualOrder> ManualOrders => Set<ManualOrder>();
         public DbSet<ManualOrderItem> ManualOrderItems => Set<ManualOrderItem>();
+        public DbSet<OrderCommission> OrderCommissions => Set<OrderCommission>();
         public DbSet<Discount> Discounts => Set<Discount>();
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
@@ -92,6 +93,15 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 entity.Property(e => e.Value).HasColumnType("decimal(18,2)");
                 entity.Property(e => e.IsActive).IsRequired();
                 entity.Property(e => e.CreatedByUserId).IsRequired();
+                entity.Property(e => e.CreatedAt).IsRequired();
+            });
+
+            builder.Entity<OrderCommission>(entity =>
+            {
+                entity.ToTable("OrderCommissions");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.CommissionRate).HasColumnType("decimal(18,4)");
+                entity.Property(e => e.EarnedAmount).HasColumnType("decimal(18,2)");
                 entity.Property(e => e.CreatedAt).IsRequired();
             });
         }

--- a/dekofar-hyperconnect-api/Controllers/OrderCommissionsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/OrderCommissionsController.cs
@@ -1,0 +1,35 @@
+using Dekofar.HyperConnect.Application.OrderCommissions.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.API.Controllers
+{
+    [ApiController]
+    [Route("api/order-commissions")]
+    [Authorize]
+    public class OrderCommissionsController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public OrderCommissionsController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet("user")]
+        public async Task<IActionResult> GetForCurrentUser()
+        {
+            var commissions = await _mediator.Send(new GetCommissionsByUserQuery());
+            return Ok(commissions);
+        }
+
+        [HttpGet("user/total")]
+        public async Task<IActionResult> GetTotalForCurrentUser()
+        {
+            var total = await _mediator.Send(new GetUserTotalCommissionQuery());
+            return Ok(total);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add OrderCommission entity and EF configuration
- Support creating commissions when manual orders are saved
- Expose endpoints to list and total commissions for current user

## Testing
- `dotnet build dekofar-hyperconnect-api.sln`

------
https://chatgpt.com/codex/tasks/task_e_688dd12092c4832696b83c3102beabe2