### PR TITLE
Add audit trail and internal notes

### DIFF
--- a/Dekofar.HyperConnect.Application/AuditLogs/Commands/CreateAuditLogCommand.cs
+++ b/Dekofar.HyperConnect.Application/AuditLogs/Commands/CreateAuditLogCommand.cs
@@ -1,0 +1,13 @@
+using MediatR;
+using System;
+
+namespace Dekofar.HyperConnect.Application.AuditLogs.Commands
+{
+    public class CreateAuditLogCommand : IRequest<Unit>
+    {
+        public string Action { get; set; } = default!;
+        public string TargetType { get; set; } = default!;
+        public Guid TargetId { get; set; }
+        public string Description { get; set; } = default!;
+    }
+}

--- a/Dekofar.HyperConnect.Application/AuditLogs/Handlers/CreateAuditLogHandler.cs
+++ b/Dekofar.HyperConnect.Application/AuditLogs/Handlers/CreateAuditLogHandler.cs
@@ -1,0 +1,43 @@
+using Dekofar.HyperConnect.Application.AuditLogs.Commands;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.AuditLogs.Handlers
+{
+    public class CreateAuditLogHandler : IRequestHandler<CreateAuditLogCommand, Unit>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public CreateAuditLogHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<Unit> Handle(CreateAuditLogCommand request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var log = new AuditLog
+            {
+                Id = Guid.NewGuid(),
+                Action = request.Action,
+                TargetType = request.TargetType,
+                TargetId = request.TargetId,
+                Description = request.Description,
+                PerformedByUserId = _currentUser.UserId.Value,
+                Timestamp = DateTime.UtcNow
+            };
+
+            await _context.AuditLogs.AddAsync(log, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+            return Unit.Value;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -16,6 +16,8 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<ManualOrderItem> ManualOrderItems { get; }
         DbSet<OrderCommission> OrderCommissions { get; }
         DbSet<Discount> Discounts { get; }
+        DbSet<Note> Notes { get; }
+        DbSet<AuditLog> AuditLogs { get; }
         DbSet<ApplicationUser> Users { get; }
         DbSet<IdentityUserRole<Guid>> UserRoles { get; }
         DbSet<IdentityRole<Guid>> Roles { get; }

--- a/Dekofar.HyperConnect.Application/Notes/Commands/AddNoteCommand.cs
+++ b/Dekofar.HyperConnect.Application/Notes/Commands/AddNoteCommand.cs
@@ -1,0 +1,12 @@
+using MediatR;
+using System;
+
+namespace Dekofar.HyperConnect.Application.Notes.Commands
+{
+    public class AddNoteCommand : IRequest<Guid>
+    {
+        public string TargetType { get; set; } = default!;
+        public Guid TargetId { get; set; }
+        public string Text { get; set; } = default!;
+    }
+}

--- a/Dekofar.HyperConnect.Application/Notes/DTOs/NoteDto.cs
+++ b/Dekofar.HyperConnect.Application/Notes/DTOs/NoteDto.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.Notes.DTOs
+{
+    public class NoteDto
+    {
+        public Guid Id { get; set; }
+        public string TargetType { get; set; } = default!;
+        public Guid TargetId { get; set; }
+        public string Text { get; set; } = default!;
+        public Guid CreatedByUserId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Notes/Handlers/AddNoteHandler.cs
+++ b/Dekofar.HyperConnect.Application/Notes/Handlers/AddNoteHandler.cs
@@ -1,0 +1,42 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.Notes.Commands;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.Notes.Handlers
+{
+    public class AddNoteHandler : IRequestHandler<AddNoteCommand, Guid>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public AddNoteHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<Guid> Handle(AddNoteCommand request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var note = new Note
+            {
+                Id = Guid.NewGuid(),
+                TargetType = request.TargetType,
+                TargetId = request.TargetId,
+                Text = request.Text,
+                CreatedByUserId = _currentUser.UserId.Value,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _context.Notes.AddAsync(note, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+            return note.Id;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Notes/Handlers/GetNotesByTargetHandler.cs
+++ b/Dekofar.HyperConnect.Application/Notes/Handlers/GetNotesByTargetHandler.cs
@@ -1,0 +1,40 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.Notes.DTOs;
+using Dekofar.HyperConnect.Application.Notes.Queries;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.Notes.Handlers
+{
+    public class GetNotesByTargetHandler : IRequestHandler<GetNotesByTargetQuery, List<NoteDto>>
+    {
+        private readonly IApplicationDbContext _context;
+
+        public GetNotesByTargetHandler(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<List<NoteDto>> Handle(GetNotesByTargetQuery request, CancellationToken cancellationToken)
+        {
+            return await _context.Notes
+                .AsNoTracking()
+                .Where(n => n.TargetType == request.TargetType && n.TargetId == request.TargetId)
+                .OrderBy(n => n.CreatedAt)
+                .Select(n => new NoteDto
+                {
+                    Id = n.Id,
+                    TargetType = n.TargetType,
+                    TargetId = n.TargetId,
+                    Text = n.Text,
+                    CreatedByUserId = n.CreatedByUserId,
+                    CreatedAt = n.CreatedAt
+                })
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Notes/Queries/GetNotesByTargetQuery.cs
+++ b/Dekofar.HyperConnect.Application/Notes/Queries/GetNotesByTargetQuery.cs
@@ -1,0 +1,19 @@
+using Dekofar.HyperConnect.Application.Notes.DTOs;
+using MediatR;
+using System;
+using System.Collections.Generic;
+
+namespace Dekofar.HyperConnect.Application.Notes.Queries
+{
+    public class GetNotesByTargetQuery : IRequest<List<NoteDto>>
+    {
+        public string TargetType { get; }
+        public Guid TargetId { get; }
+
+        public GetNotesByTargetQuery(string targetType, Guid targetId)
+        {
+            TargetType = targetType;
+            TargetId = targetId;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/SupportTickets/Handlers/AssignSupportTicketHandler.cs
+++ b/Dekofar.HyperConnect.Application/SupportTickets/Handlers/AssignSupportTicketHandler.cs
@@ -1,3 +1,4 @@
+using Dekofar.HyperConnect.Application.AuditLogs.Commands;
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Application.SupportTickets.Commands;
 using MediatR;
@@ -10,10 +11,12 @@ namespace Dekofar.HyperConnect.Application.SupportTickets.Handlers
     public class AssignSupportTicketHandler : IRequestHandler<AssignSupportTicketCommand, Unit>
     {
         private readonly IApplicationDbContext _context;
+        private readonly IMediator _mediator;
 
-        public AssignSupportTicketHandler(IApplicationDbContext context)
+        public AssignSupportTicketHandler(IApplicationDbContext context, IMediator mediator)
         {
             _context = context;
+            _mediator = mediator;
         }
 
         public async Task<Unit> Handle(AssignSupportTicketCommand request, CancellationToken cancellationToken)
@@ -25,6 +28,15 @@ namespace Dekofar.HyperConnect.Application.SupportTickets.Handlers
             ticket.AssignedUserId = request.AssignedUserId;
             ticket.LastUpdatedAt = DateTime.UtcNow;
             await _context.SaveChangesAsync(cancellationToken);
+
+            await _mediator.Send(new CreateAuditLogCommand
+            {
+                Action = "AssignTicket",
+                TargetType = "SupportTicket",
+                TargetId = ticket.Id,
+                Description = $"Assigned to user {request.AssignedUserId}"
+            }, cancellationToken);
+
             return Unit.Value;
         }
     }

--- a/Dekofar.HyperConnect.Domain/Entities/AuditLog.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/AuditLog.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class AuditLog
+    {
+        public Guid Id { get; set; }
+        public string Action { get; set; } = default!;
+        public string TargetType { get; set; } = default!;
+        public Guid TargetId { get; set; }
+        public string Description { get; set; } = default!;
+        public Guid PerformedByUserId { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/Note.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/Note.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class Note
+    {
+        public Guid Id { get; set; }
+        public string TargetType { get; set; } = default!;
+        public Guid TargetId { get; set; }
+        public string Text { get; set; } = default!;
+        public Guid CreatedByUserId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -26,6 +26,8 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<ManualOrderItem> ManualOrderItems => Set<ManualOrderItem>();
         public DbSet<OrderCommission> OrderCommissions => Set<OrderCommission>();
         public DbSet<Discount> Discounts => Set<Discount>();
+        public DbSet<Note> Notes => Set<Note>();
+        public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => await base.SaveChangesAsync(cancellationToken);
@@ -103,6 +105,25 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 entity.Property(e => e.CommissionRate).HasColumnType("decimal(18,4)");
                 entity.Property(e => e.EarnedAmount).HasColumnType("decimal(18,2)");
                 entity.Property(e => e.CreatedAt).IsRequired();
+            });
+
+            builder.Entity<Note>(entity =>
+            {
+                entity.ToTable("Notes");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.TargetType).IsRequired();
+                entity.Property(e => e.Text).IsRequired();
+                entity.Property(e => e.CreatedAt).IsRequired();
+            });
+
+            builder.Entity<AuditLog>(entity =>
+            {
+                entity.ToTable("AuditLogs");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Action).IsRequired();
+                entity.Property(e => e.TargetType).IsRequired();
+                entity.Property(e => e.Description);
+                entity.Property(e => e.Timestamp).IsRequired();
             });
         }
     }

--- a/dekofar-hyperconnect-api/Controllers/NotesController.cs
+++ b/dekofar-hyperconnect-api/Controllers/NotesController.cs
@@ -1,0 +1,37 @@
+using Dekofar.HyperConnect.Application.Notes.Commands;
+using Dekofar.HyperConnect.Application.Notes.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.API.Controllers
+{
+    [ApiController]
+    [Route("api/notes")]
+    [Authorize]
+    public class NotesController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public NotesController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet("{targetType}/{targetId}")]
+        public async Task<IActionResult> GetByTarget(string targetType, Guid targetId)
+        {
+            var notes = await _mediator.Send(new GetNotesByTargetQuery(targetType, targetId));
+            return Ok(notes);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Add([FromBody] AddNoteCommand command)
+        {
+            var id = await _mediator.Send(command);
+            return Ok(id);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `AuditLog` and `Note` entities for tracking actions and internal comments
- expose commands/handlers and API endpoints to create and list notes
- record an audit entry when tickets are assigned

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_688dd32956c88326bcaaf434a4427e72