### PR TITLE
feat: add permission-based authorization

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -21,6 +21,8 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<ApplicationUser> Users { get; }
         DbSet<IdentityUserRole<Guid>> UserRoles { get; }
         DbSet<IdentityRole<Guid>> Roles { get; }
+        DbSet<Permission> Permissions { get; }
+        DbSet<RolePermission> RolePermissions { get; }
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/Permission.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/Permission.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class Permission
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = default!;
+        public string? Description { get; set; }
+        public ICollection<RolePermission>? RolePermissions { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/RolePermission.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/RolePermission.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class RolePermission
+    {
+        public Guid Id { get; set; }
+        public string RoleName { get; set; } = default!;
+        public Guid PermissionId { get; set; }
+
+        public Permission? Permission { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -28,6 +28,8 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<Discount> Discounts => Set<Discount>();
         public DbSet<Note> Notes => Set<Note>();
         public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+        public DbSet<Permission> Permissions => Set<Permission>();
+        public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => await base.SaveChangesAsync(cancellationToken);
@@ -124,6 +126,25 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 entity.Property(e => e.TargetType).IsRequired();
                 entity.Property(e => e.Description);
                 entity.Property(e => e.Timestamp).IsRequired();
+            });
+
+            builder.Entity<Permission>(entity =>
+            {
+                entity.ToTable("Permissions");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.Description).HasMaxLength(250);
+            });
+
+            builder.Entity<RolePermission>(entity =>
+            {
+                entity.ToTable("RolePermissions");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.RoleName).IsRequired().HasMaxLength(100);
+                entity.HasOne(rp => rp.Permission)
+                      .WithMany(p => p.RolePermissions)
+                      .HasForeignKey(rp => rp.PermissionId)
+                      .OnDelete(DeleteBehavior.Cascade);
             });
         }
     }

--- a/Dekofar.HyperConnect.Infrastructure/Services/SeedData.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/SeedData.cs
@@ -83,6 +83,39 @@ namespace Dekofar.HyperConnect.Infrastructure.Services
                 context.SupportTickets.Add(ticket);
                 await context.SaveChangesAsync();
             }
+
+            var defaultPermissions = new[]
+            {
+                new Permission { Id = Guid.NewGuid(), Name = "CanAssignTicket", Description = "Assign support tickets" },
+                new Permission { Id = Guid.NewGuid(), Name = "CanManageDiscounts", Description = "Manage discounts" },
+                new Permission { Id = Guid.NewGuid(), Name = "CanEditDueDate", Description = "Edit ticket due dates" }
+            };
+
+            foreach (var perm in defaultPermissions)
+            {
+                if (!await context.Permissions.AnyAsync(p => p.Name == perm.Name))
+                {
+                    context.Permissions.Add(perm);
+                }
+            }
+            await context.SaveChangesAsync();
+
+            var adminRoleName = "Admin";
+            var adminPermissions = await context.Permissions.ToListAsync();
+
+            foreach (var perm in adminPermissions)
+            {
+                if (!await context.RolePermissions.AnyAsync(rp => rp.RoleName == adminRoleName && rp.PermissionId == perm.Id))
+                {
+                    context.RolePermissions.Add(new RolePermission
+                    {
+                        Id = Guid.NewGuid(),
+                        RoleName = adminRoleName,
+                        PermissionId = perm.Id
+                    });
+                }
+            }
+            await context.SaveChangesAsync();
         }
     }
 }

--- a/dekofar-hyperconnect-api/Authorization/PermissionAuthorizationHandler.cs
+++ b/dekofar-hyperconnect-api/Authorization/PermissionAuthorizationHandler.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.API.Authorization;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.API.Authorization
+{
+    public class PermissionAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IApplicationDbContext _context;
+
+        public PermissionAuthorizationHandler(UserManager<ApplicationUser> userManager, IApplicationDbContext context)
+        {
+            _userManager = userManager;
+            _context = context;
+        }
+
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+        {
+            var userId = context.User?.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+            if (userId == null)
+            {
+                return;
+            }
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return;
+            }
+
+            var roles = await _userManager.GetRolesAsync(user);
+            var permission = await _context.Permissions
+                .Include(p => p.RolePermissions)
+                .FirstOrDefaultAsync(p => p.Name == requirement.Permission);
+
+            if (permission == null)
+                return;
+
+            var hasPermission = permission.RolePermissions != null &&
+                                permission.RolePermissions.Any(rp => roles.Contains(rp.RoleName));
+
+            if (hasPermission)
+            {
+                context.Succeed(requirement);
+            }
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Authorization/PermissionRequirement.cs
+++ b/dekofar-hyperconnect-api/Authorization/PermissionRequirement.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Dekofar.HyperConnect.API.Authorization
+{
+    public class PermissionRequirement : IAuthorizationRequirement
+    {
+        public string Permission { get; }
+
+        public PermissionRequirement(string permission)
+        {
+            Permission = permission;
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/DiscountsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/DiscountsController.cs
@@ -36,7 +36,7 @@ namespace Dekofar.HyperConnect.API.Controllers
         }
 
         [HttpPost]
-        [Authorize(Roles = "Admin,CanManageDiscounts")]
+        [Authorize(Policy = "CanManageDiscounts")]
         public async Task<IActionResult> Create([FromBody] CreateDiscountCommand command)
         {
             var id = await _mediator.Send(command);
@@ -44,7 +44,7 @@ namespace Dekofar.HyperConnect.API.Controllers
         }
 
         [HttpPut("{id}")]
-        [Authorize(Roles = "Admin,CanManageDiscounts")]
+        [Authorize(Policy = "CanManageDiscounts")]
         public async Task<IActionResult> Update(Guid id, [FromBody] UpdateDiscountCommand command)
         {
             if (id != command.Id) return BadRequest();
@@ -53,7 +53,7 @@ namespace Dekofar.HyperConnect.API.Controllers
         }
 
         [HttpDelete("{id}")]
-        [Authorize(Roles = "Admin,CanManageDiscounts")]
+        [Authorize(Policy = "CanManageDiscounts")]
         public async Task<IActionResult> Delete(Guid id)
         {
             await _mediator.Send(new DeleteDiscountCommand(id));

--- a/dekofar-hyperconnect-api/Controllers/PermissionsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/PermissionsController.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.API.Controllers
+{
+    [ApiController]
+    public class PermissionsController : ControllerBase
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly RoleManager<IdentityRole<Guid>> _roleManager;
+
+        public PermissionsController(IApplicationDbContext context, RoleManager<IdentityRole<Guid>> roleManager)
+        {
+            _context = context;
+            _roleManager = roleManager;
+        }
+
+        [HttpGet("api/permissions")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> GetAll()
+        {
+            var permissions = await _context.Permissions.AsNoTracking().ToListAsync();
+            return Ok(permissions);
+        }
+
+        [HttpPost("api/roles/{role}/permissions")]
+        [Authorize(Roles = "Admin")]
+        public async Task<IActionResult> AssignToRole(string role, [FromBody] List<Guid> permissionIds)
+        {
+            var roleEntity = await _roleManager.FindByNameAsync(role);
+            if (roleEntity == null)
+                return NotFound();
+
+            var existing = _context.RolePermissions.Where(rp => rp.RoleName == role);
+            _context.RolePermissions.RemoveRange(existing);
+
+            foreach (var id in permissionIds)
+            {
+                _context.RolePermissions.Add(new RolePermission
+                {
+                    Id = Guid.NewGuid(),
+                    RoleName = role,
+                    PermissionId = id
+                });
+            }
+
+            await _context.SaveChangesAsync();
+            return Ok();
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/SupportTicketsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/SupportTicketsController.cs
@@ -44,7 +44,7 @@ namespace Dekofar.HyperConnect.API.Controllers
         }
 
         [HttpPost("{id}/assign")]
-        [Authorize(Roles = "Admin")]
+        [Authorize(Policy = "CanAssignTicket")]
         public async Task<IActionResult> Assign(Guid id, [FromBody] AssignSupportTicketCommand command)
         {
             if (id != command.TicketId) return BadRequest();

--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -11,11 +11,13 @@ using Dekofar.HyperConnect.Integrations.Shopify.Interfaces;
 using Dekofar.HyperConnect.Integrations.Shopify.Services;
 using Dekofar.HyperConnect.Application; // Application servis kayıtları
 using Dekofar.HyperConnect.Infrastructure.Services;
+using Dekofar.HyperConnect.API.Authorization;
 using MediatR;
 using Dekofar.HyperConnect.Infrastructure.ServiceRegistration;
 using Hangfire;
 using Hangfire.MemoryStorage;
 using Dekofar.HyperConnect.Infrastructure.Jobs;
+using Microsoft.AspNetCore.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,6 +42,18 @@ builder.Services.AddCors(options =>
 builder.Services.AddInfrastructure(builder.Configuration);
 builder.Services.AddMemoryCache();
 builder.Services.AddApplication();
+
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("CanAssignTicket", policy =>
+        policy.Requirements.Add(new PermissionRequirement("CanAssignTicket")));
+    options.AddPolicy("CanManageDiscounts", policy =>
+        policy.Requirements.Add(new PermissionRequirement("CanManageDiscounts")));
+    options.AddPolicy("CanEditDueDate", policy =>
+        policy.Requirements.Add(new PermissionRequirement("CanEditDueDate")));
+});
+
+builder.Services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
 
 builder.Services.AddHangfire(config =>
 {


### PR DESCRIPTION
## Summary
- add Permission and RolePermission entities
- enforce access via new permission-based policies
- seed default permissions and expose management endpoints

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688dd75cd7708326b858f3ca043c7614