### PR TITLE
Skip identity tables in EF Core migrations

### DIFF
--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -38,6 +38,14 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         {
             base.OnModelCreating(builder);
 
+            builder.Entity<ApplicationUser>().ToTable("AspNetUsers", t => t.ExcludeFromMigrations());
+            builder.Entity<IdentityRole<Guid>>().ToTable("AspNetRoles", t => t.ExcludeFromMigrations());
+            builder.Entity<IdentityUserRole<Guid>>().ToTable("AspNetUserRoles", t => t.ExcludeFromMigrations());
+            builder.Entity<IdentityUserClaim<Guid>>().ToTable("AspNetUserClaims", t => t.ExcludeFromMigrations());
+            builder.Entity<IdentityUserLogin<Guid>>().ToTable("AspNetUserLogins", t => t.ExcludeFromMigrations());
+            builder.Entity<IdentityUserToken<Guid>>().ToTable("AspNetUserTokens", t => t.ExcludeFromMigrations());
+            builder.Entity<IdentityRoleClaim<Guid>>().ToTable("AspNetRoleClaims", t => t.ExcludeFromMigrations());
+
             builder.Entity<SupportCategory>(entity =>
             {
                 entity.ToTable("SupportCategories");

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/Migrations/20250802095211_SyncEntitiesWithDatabase.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/Migrations/20250802095211_SyncEntitiesWithDatabase.Designer.cs
@@ -93,7 +93,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
                         .IsUnique()
                         .HasDatabaseName("UserNameIndex");
 
-                    b.ToTable("AspNetUsers", (string)null);
+                    b.ToTable("AspNetUsers", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.AuditLog", b =>
@@ -545,7 +545,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
                         .IsUnique()
                         .HasDatabaseName("RoleNameIndex");
 
-                    b.ToTable("AspNetRoles", (string)null);
+                    b.ToTable("AspNetRoles", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
@@ -569,7 +569,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("RoleId");
 
-                    b.ToTable("AspNetRoleClaims", (string)null);
+                    b.ToTable("AspNetRoleClaims", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
@@ -593,7 +593,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("AspNetUserClaims", (string)null);
+                    b.ToTable("AspNetUserClaims", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
@@ -614,7 +614,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("AspNetUserLogins", (string)null);
+                    b.ToTable("AspNetUserLogins", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
@@ -629,7 +629,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("RoleId");
 
-                    b.ToTable("AspNetUserRoles", (string)null);
+                    b.ToTable("AspNetUserRoles", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
@@ -648,7 +648,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasKey("UserId", "LoginProvider", "Name");
 
-                    b.ToTable("AspNetUserTokens", (string)null);
+                    b.ToTable("AspNetUserTokens", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ManualOrderItem", b =>

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -90,7 +90,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
                         .IsUnique()
                         .HasDatabaseName("UserNameIndex");
 
-                    b.ToTable("AspNetUsers", (string)null);
+                    b.ToTable("AspNetUsers", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.AuditLog", b =>
@@ -542,7 +542,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
                         .IsUnique()
                         .HasDatabaseName("RoleNameIndex");
 
-                    b.ToTable("AspNetRoles", (string)null);
+                    b.ToTable("AspNetRoles", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
@@ -566,7 +566,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("RoleId");
 
-                    b.ToTable("AspNetRoleClaims", (string)null);
+                    b.ToTable("AspNetRoleClaims", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
@@ -590,7 +590,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("AspNetUserClaims", (string)null);
+                    b.ToTable("AspNetUserClaims", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
@@ -611,7 +611,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("UserId");
 
-                    b.ToTable("AspNetUserLogins", (string)null);
+                    b.ToTable("AspNetUserLogins", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
@@ -626,7 +626,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasIndex("RoleId");
 
-                    b.ToTable("AspNetUserRoles", (string)null);
+                    b.ToTable("AspNetUserRoles", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
@@ -645,7 +645,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence.Migrations
 
                     b.HasKey("UserId", "LoginProvider", "Name");
 
-                    b.ToTable("AspNetUserTokens", (string)null);
+                    b.ToTable("AspNetUserTokens", (string)null, t => t.ExcludeFromMigrations());
                 });
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ManualOrderItem", b =>


### PR DESCRIPTION
## Summary
- prevent EF Core from recreating existing Identity tables by excluding them from migrations
- regenerate model snapshot and designer to mark Identity tables as `ExcludeFromMigrations`

## Testing
- `dotnet build`
- `dotnet ef database update --project Dekofar.HyperConnect.Infrastructure --startup-project dekofar-hyperconnect-api --connection "Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres"`


------
https://chatgpt.com/codex/tasks/task_e_688de78d07ec8326bbad5d985f9445cb