### PR TITLE
feat: extend user profile with activity metrics

### DIFF
--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -13,5 +13,15 @@ namespace Dekofar.Domain.Entities
         /// </summary>
         public string? AvatarUrl { get; set; }
 
+        public DateTime MembershipDate { get; set; }
+        public bool IsOnline { get; set; }
+        public DateTime? LastSeen { get; set; }
+        public int TotalSalesCount { get; set; }
+        public decimal TotalCommissionAmount { get; set; }
+        public int TotalSupportRequestCount { get; set; }
+        public int UnreadMessageCount { get; set; }
+        public DateTime? LastMessageDate { get; set; }
+        public DateTime? LastSupportActivity { get; set; }
+
     }
 }

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802155824_ExtendUserProfile.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802155824_ExtendUserProfile.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Dekofar.HyperConnect.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802155824_ExtendUserProfile")]
+    partial class ExtendUserProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802155824_ExtendUserProfile.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802155824_ExtendUserProfile.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dekofar.HyperConnect.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExtendUserProfile : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsOnline",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastMessageDate",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastSeen",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastSupportActivity",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "MembershipDate",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<decimal>(
+                name: "TotalCommissionAmount",
+                table: "AspNetUsers",
+                type: "numeric",
+                nullable: false,
+                defaultValue: 0m);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotalSalesCount",
+                table: "AspNetUsers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "TotalSupportRequestCount",
+                table: "AspNetUsers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UnreadMessageCount",
+                table: "AspNetUsers",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsOnline",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastMessageDate",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastSeen",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "LastSupportActivity",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "MembershipDate",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TotalCommissionAmount",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TotalSalesCount",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "TotalSupportRequestCount",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "UnreadMessageCount",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Services/SeedData.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/SeedData.cs
@@ -37,7 +37,8 @@ namespace Dekofar.HyperConnect.Infrastructure.Services
                 adminUser = new ApplicationUser
                 {
                     UserName = adminEmail,
-                    Email = adminEmail
+                    Email = adminEmail,
+                    MembershipDate = DateTime.UtcNow
                 };
                 var createUserResult = await userManager.CreateAsync(adminUser, adminPassword);
                 if (!createUserResult.Succeeded)

--- a/dekofar-hyperconnect-api/Controllers/Auth/AuthController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Auth/AuthController.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System;
 using System.Security.Claims;
 
 namespace Dekofar.API.Controllers
@@ -48,7 +49,8 @@ namespace Dekofar.API.Controllers
                 {
                     UserName = request.Email,
                     Email = request.Email,
-                    FullName = request.FullName
+                    FullName = request.FullName,
+                    MembershipDate = DateTime.UtcNow
                 };
 
                 var result = await _userManager.CreateAsync(user, request.Password);
@@ -96,7 +98,8 @@ namespace Dekofar.API.Controllers
             {
                 UserName = request.Email,
                 Email = request.Email,
-                FullName = request.FullName
+                FullName = request.FullName,
+                MembershipDate = DateTime.UtcNow
             };
 
             var result = await userManager.CreateAsync(user, request.Password);
@@ -122,7 +125,8 @@ namespace Dekofar.API.Controllers
             {
                 UserName = request.Email,
                 Email = request.Email,
-                FullName = request.FullName
+                FullName = request.FullName,
+                MembershipDate = DateTime.UtcNow
             };
 
             var result = await _userManager.CreateAsync(user, request.Password);


### PR DESCRIPTION
## Summary
- expand `ApplicationUser` with membership, activity, sales and messaging stats
- record registration date for new users and seeded admin user
- add EF Core migration for new user fields

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688e341d0d388326a5ec09d21a00cf84