### PR TITLE
Add user messaging system

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -23,6 +23,7 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<IdentityRole<Guid>> Roles { get; }
         DbSet<Permission> Permissions { get; }
         DbSet<RolePermission> RolePermissions { get; }
+        DbSet<UserMessage> UserMessages { get; }
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IFileStorageService.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IFileStorageService.cs
@@ -7,5 +7,6 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
     public interface IFileStorageService
     {
         Task<string> SaveProfileImageAsync(IFormFile file, Guid userId);
+        Task<string> SaveChatAttachmentAsync(IFormFile file, Guid userId);
     }
 }

--- a/Dekofar.HyperConnect.Application/UserMessages/Commands/MarkMessagesAsReadCommand.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Commands/MarkMessagesAsReadCommand.cs
@@ -1,0 +1,15 @@
+using System;
+using MediatR;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Commands
+{
+    public class MarkMessagesAsReadCommand : IRequest<int>
+    {
+        public Guid ChatUserId { get; }
+
+        public MarkMessagesAsReadCommand(Guid chatUserId)
+        {
+            ChatUserId = chatUserId;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Commands/SendUserMessageCommand.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Commands/SendUserMessageCommand.cs
@@ -1,0 +1,14 @@
+using System;
+using Dekofar.HyperConnect.Application.UserMessages.DTOs;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Commands
+{
+    public class SendUserMessageCommand : IRequest<UserMessageDto>
+    {
+        public Guid ReceiverId { get; set; }
+        public string? Text { get; set; }
+        public IFormFile? File { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/DTOs/UserMessageDto.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/DTOs/UserMessageDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.DTOs
+{
+    public class UserMessageDto
+    {
+        public Guid Id { get; set; }
+        public Guid SenderId { get; set; }
+        public Guid ReceiverId { get; set; }
+        public string? Text { get; set; }
+        public string? AttachmentUrl { get; set; }
+        public DateTime SentAt { get; set; }
+        public bool IsRead { get; set; }
+        public DateTime? ReadAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Handlers/GetChatMessagesHandler.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Handlers/GetChatMessagesHandler.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.UserMessages.DTOs;
+using Dekofar.HyperConnect.Application.UserMessages.Queries;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Handlers
+{
+    public class GetChatMessagesHandler : IRequestHandler<GetChatMessagesQuery, List<UserMessageDto>>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUserService;
+
+        public GetChatMessagesHandler(IApplicationDbContext context, ICurrentUserService currentUserService)
+        {
+            _context = context;
+            _currentUserService = currentUserService;
+        }
+
+        public async Task<List<UserMessageDto>> Handle(GetChatMessagesQuery request, CancellationToken cancellationToken)
+        {
+            if (_currentUserService.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var currentUserId = _currentUserService.UserId.Value;
+
+            return await _context.UserMessages
+                .AsNoTracking()
+                .Where(m => (m.SenderId == currentUserId && m.ReceiverId == request.ChatUserId) ||
+                            (m.SenderId == request.ChatUserId && m.ReceiverId == currentUserId))
+                .OrderBy(m => m.SentAt)
+                .Select(m => new UserMessageDto
+                {
+                    Id = m.Id,
+                    SenderId = m.SenderId,
+                    ReceiverId = m.ReceiverId,
+                    Text = m.Text,
+                    AttachmentUrl = m.AttachmentUrl,
+                    SentAt = m.SentAt,
+                    IsRead = m.IsRead,
+                    ReadAt = m.ReadAt
+                })
+                .ToListAsync(cancellationToken);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Handlers/GetUnreadMessageCountHandler.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Handlers/GetUnreadMessageCountHandler.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.UserMessages.Queries;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Handlers
+{
+    public class GetUnreadMessageCountHandler : IRequestHandler<GetUnreadMessageCountQuery, int>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUserService;
+
+        public GetUnreadMessageCountHandler(IApplicationDbContext context, ICurrentUserService currentUserService)
+        {
+            _context = context;
+            _currentUserService = currentUserService;
+        }
+
+        public async Task<int> Handle(GetUnreadMessageCountQuery request, CancellationToken cancellationToken)
+        {
+            if (_currentUserService.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var currentUserId = _currentUserService.UserId.Value;
+
+            return await _context.UserMessages
+                .AsNoTracking()
+                .CountAsync(m => m.ReceiverId == currentUserId && !m.IsRead, cancellationToken);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Handlers/MarkMessagesAsReadHandler.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Handlers/MarkMessagesAsReadHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.UserMessages.Commands;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Handlers
+{
+    public class MarkMessagesAsReadHandler : IRequestHandler<MarkMessagesAsReadCommand, int>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUserService;
+
+        public MarkMessagesAsReadHandler(IApplicationDbContext context, ICurrentUserService currentUserService)
+        {
+            _context = context;
+            _currentUserService = currentUserService;
+        }
+
+        public async Task<int> Handle(MarkMessagesAsReadCommand request, CancellationToken cancellationToken)
+        {
+            if (_currentUserService.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var currentUserId = _currentUserService.UserId.Value;
+
+            var messages = await _context.UserMessages
+                .Where(m => m.SenderId == request.ChatUserId && m.ReceiverId == currentUserId && !m.IsRead)
+                .ToListAsync(cancellationToken);
+
+            foreach (var message in messages)
+            {
+                message.IsRead = true;
+                message.ReadAt = DateTime.UtcNow;
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+
+            return messages.Count;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Handlers/SendUserMessageHandler.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Handlers/SendUserMessageHandler.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.UserMessages.Commands;
+using Dekofar.HyperConnect.Application.UserMessages.DTOs;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Handlers
+{
+    public class SendUserMessageHandler : IRequestHandler<SendUserMessageCommand, UserMessageDto>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUserService;
+        private readonly IFileStorageService _fileStorageService;
+
+        public SendUserMessageHandler(IApplicationDbContext context, ICurrentUserService currentUserService, IFileStorageService fileStorageService)
+        {
+            _context = context;
+            _currentUserService = currentUserService;
+            _fileStorageService = fileStorageService;
+        }
+
+        public async Task<UserMessageDto> Handle(SendUserMessageCommand request, CancellationToken cancellationToken)
+        {
+            if (_currentUserService.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            string? attachmentUrl = null;
+            if (request.File != null)
+            {
+                attachmentUrl = await _fileStorageService.SaveChatAttachmentAsync(request.File, _currentUserService.UserId.Value);
+            }
+
+            var message = new UserMessage
+            {
+                Id = Guid.NewGuid(),
+                SenderId = _currentUserService.UserId.Value,
+                ReceiverId = request.ReceiverId,
+                Text = request.Text,
+                AttachmentUrl = attachmentUrl,
+                SentAt = DateTime.UtcNow,
+                IsRead = false
+            };
+
+            await _context.UserMessages.AddAsync(message, cancellationToken);
+            await _context.SaveChangesAsync(cancellationToken);
+
+            return new UserMessageDto
+            {
+                Id = message.Id,
+                SenderId = message.SenderId,
+                ReceiverId = message.ReceiverId,
+                Text = message.Text,
+                AttachmentUrl = message.AttachmentUrl,
+                SentAt = message.SentAt,
+                IsRead = message.IsRead,
+                ReadAt = message.ReadAt
+            };
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Queries/GetChatMessagesQuery.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Queries/GetChatMessagesQuery.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using Dekofar.HyperConnect.Application.UserMessages.DTOs;
+using MediatR;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Queries
+{
+    public class GetChatMessagesQuery : IRequest<List<UserMessageDto>>
+    {
+        public Guid ChatUserId { get; }
+
+        public GetChatMessagesQuery(Guid chatUserId)
+        {
+            ChatUserId = chatUserId;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UserMessages/Queries/GetUnreadMessageCountQuery.cs
+++ b/Dekofar.HyperConnect.Application/UserMessages/Queries/GetUnreadMessageCountQuery.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Dekofar.HyperConnect.Application.UserMessages.Queries
+{
+    public class GetUnreadMessageCountQuery : IRequest<int>
+    {
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/UserMessage.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/UserMessage.cs
@@ -1,0 +1,26 @@
+using System;
+using Dekofar.Domain.Entities;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class UserMessage
+    {
+        public Guid Id { get; set; }
+
+        public Guid SenderId { get; set; }
+        public ApplicationUser Sender { get; set; } = default!;
+
+        public Guid ReceiverId { get; set; }
+        public ApplicationUser Receiver { get; set; } = default!;
+
+        public string? Text { get; set; }
+
+        public string? AttachmentUrl { get; set; }
+
+        public DateTime SentAt { get; set; }
+
+        public bool IsRead { get; set; } = false;
+
+        public DateTime? ReadAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802161302_AddUserMessages.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802161302_AddUserMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Dekofar.HyperConnect.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802161302_AddUserMessages")]
+    partial class AddUserMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802161302_AddUserMessages.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802161302_AddUserMessages.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dekofar.HyperConnect.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SenderId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ReceiverId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Text = table.Column<string>(type: "text", nullable: true),
+                    AttachmentUrl = table.Column<string>(type: "text", nullable: true),
+                    SentAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsRead = table.Column<bool>(type: "boolean", nullable: false),
+                    ReadAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_UserMessages_AspNetUsers_ReceiverId",
+                        column: x => x.ReceiverId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_UserMessages_AspNetUsers_SenderId",
+                        column: x => x.SenderId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserMessages_ReceiverId",
+                table: "UserMessages",
+                column: "ReceiverId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserMessages_SenderId",
+                table: "UserMessages",
+                column: "SenderId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserMessages");
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -30,6 +30,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
         public DbSet<Permission> Permissions => Set<Permission>();
         public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
+        public DbSet<UserMessage> UserMessages => Set<UserMessage>();
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => await base.SaveChangesAsync(cancellationToken);
@@ -146,6 +147,20 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                       .WithMany(p => p.RolePermissions)
                       .HasForeignKey(rp => rp.PermissionId)
                       .OnDelete(DeleteBehavior.Cascade);
+            });
+
+            builder.Entity<UserMessage>(entity =>
+            {
+                entity.ToTable("UserMessages");
+                entity.HasKey(e => e.Id);
+                entity.HasOne(e => e.Sender)
+                      .WithMany()
+                      .HasForeignKey(e => e.SenderId)
+                      .OnDelete(DeleteBehavior.Restrict);
+                entity.HasOne(e => e.Receiver)
+                      .WithMany()
+                      .HasForeignKey(e => e.ReceiverId)
+                      .OnDelete(DeleteBehavior.Restrict);
             });
         }
     }

--- a/Dekofar.HyperConnect.Infrastructure/Services/LocalFileStorageService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/LocalFileStorageService.cs
@@ -21,5 +21,20 @@ namespace Dekofar.HyperConnect.Infrastructure.Services
 
             return $"/uploads/avatars/{userId}.jpg";
         }
+
+        public async Task<string> SaveChatAttachmentAsync(IFormFile file, Guid userId)
+        {
+            var uploadsRoot = Path.Combine(Directory.GetCurrentDirectory(), "uploads", "chat", userId.ToString());
+            Directory.CreateDirectory(uploadsRoot);
+
+            var fileName = $"{Guid.NewGuid()}{Path.GetExtension(file.FileName)}";
+            var filePath = Path.Combine(uploadsRoot, fileName);
+            using (var stream = new FileStream(filePath, FileMode.Create))
+            {
+                await file.CopyToAsync(stream);
+            }
+
+            return $"/uploads/chat/{userId}/{fileName}";
+        }
     }
 }

--- a/dekofar-hyperconnect-api/Controllers/UserMessages/UserMessagesController.cs
+++ b/dekofar-hyperconnect-api/Controllers/UserMessages/UserMessagesController.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.UserMessages.Commands;
+using Dekofar.HyperConnect.Application.UserMessages.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dekofar.API.Controllers
+{
+    [ApiController]
+    [Route("api/usermessages")]
+    [Authorize]
+    public class UserMessagesController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public UserMessagesController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet("chat/{userId}")]
+        public async Task<IActionResult> GetChat(Guid userId)
+        {
+            var messages = await _mediator.Send(new GetChatMessagesQuery(userId));
+            return Ok(messages);
+        }
+
+        [HttpPost("send")]
+        public async Task<IActionResult> Send([FromForm] SendUserMessageCommand command)
+        {
+            var message = await _mediator.Send(command);
+            return Ok(message);
+        }
+
+        [HttpGet("unread-count")]
+        public async Task<IActionResult> GetUnreadCount()
+        {
+            var count = await _mediator.Send(new GetUnreadMessageCountQuery());
+            return Ok(count);
+        }
+
+        [HttpPut("mark-as-read/{chatUserId}")]
+        public async Task<IActionResult> MarkAsRead(Guid chatUserId)
+        {
+            var updated = await _mediator.Send(new MarkMessagesAsReadCommand(chatUserId));
+            return Ok(updated);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserMessage` entity and storage for user-to-user chat
- implement messaging commands, queries, handlers, and API endpoints
- support optional attachment uploads with file storage service

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_688e36fffc908326b5708e5b9693ae36