### PR TITLE
feat: add SignalR live chat hub

### DIFF
--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -18,6 +18,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Reflection.Metadata;
 using System.Security.Claims;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
 {
@@ -69,6 +70,19 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
                     IssuerSigningKey = new SymmetricSecurityKey(key),
                     ClockSkew = TimeSpan.Zero,
                     RoleClaimType = ClaimTypes.Role
+                };
+                options.Events = new JwtBearerEvents
+                {
+                    OnMessageReceived = context =>
+                    {
+                        var accessToken = context.Request.Query["access_token"];
+                        var path = context.HttpContext.Request.Path;
+                        if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/chatHub"))
+                        {
+                            context.Token = accessToken;
+                        }
+                        return Task.CompletedTask;
+                    }
                 };
             });
             services.AddHttpContextAccessor(); // gerekli

--- a/dekofar-hyperconnect-api/Hubs/LiveChatHub.cs
+++ b/dekofar-hyperconnect-api/Hubs/LiveChatHub.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Dekofar.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Dekofar.API.Hubs
+{
+    [Authorize]
+    public class LiveChatHub : Hub
+    {
+        public static readonly ConcurrentDictionary<string, string> ConnectedUsers = new();
+        private readonly IApplicationDbContext _context;
+
+        public LiveChatHub(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public override async Task OnConnectedAsync()
+        {
+            var userId = Context.UserIdentifier;
+            if (!string.IsNullOrEmpty(userId))
+            {
+                ConnectedUsers[userId] = Context.ConnectionId;
+
+                if (Guid.TryParse(userId, out var guid))
+                {
+                    var user = await _context.Users.FindAsync(guid);
+                    if (user != null)
+                    {
+                        user.IsOnline = true;
+                        await _context.SaveChangesAsync();
+                    }
+                }
+            }
+
+            await base.OnConnectedAsync();
+        }
+
+        public override async Task OnDisconnectedAsync(Exception? exception)
+        {
+            var userId = Context.UserIdentifier;
+            if (!string.IsNullOrEmpty(userId))
+            {
+                ConnectedUsers.TryRemove(userId, out _);
+
+                if (Guid.TryParse(userId, out var guid))
+                {
+                    var user = await _context.Users.FindAsync(guid);
+                    if (user != null)
+                    {
+                        user.IsOnline = false;
+                        user.LastSeen = DateTime.UtcNow;
+                        await _context.SaveChangesAsync();
+                    }
+                }
+            }
+
+            await base.OnDisconnectedAsync(exception);
+        }
+
+        public async Task SendMessage(string receiverId, string text, string? fileUrl = null)
+        {
+            var senderId = Context.UserIdentifier;
+            if (string.IsNullOrEmpty(senderId) || string.IsNullOrEmpty(receiverId))
+                return;
+
+            if (!Guid.TryParse(senderId, out var senderGuid) || !Guid.TryParse(receiverId, out var receiverGuid))
+                return;
+
+            var message = new UserMessage
+            {
+                Id = Guid.NewGuid(),
+                SenderId = senderGuid,
+                ReceiverId = receiverGuid,
+                Text = text,
+                AttachmentUrl = fileUrl,
+                SentAt = DateTime.UtcNow,
+                IsRead = false
+            };
+
+            await _context.UserMessages.AddAsync(message);
+
+            var sender = await _context.Users.FindAsync(senderGuid);
+            if (sender != null)
+            {
+                sender.LastMessageDate = message.SentAt;
+            }
+
+            var receiver = await _context.Users.FindAsync(receiverGuid);
+            if (receiver != null)
+            {
+                receiver.LastMessageDate = message.SentAt;
+            }
+
+            await _context.SaveChangesAsync();
+
+            if (ConnectedUsers.TryGetValue(receiverId, out var connectionId))
+            {
+                await Clients.Client(connectionId).SendAsync("ReceiveMessage", new
+                {
+                    senderId,
+                    receiverId,
+                    text,
+                    fileUrl,
+                    sentAt = message.SentAt
+                });
+            }
+        }
+    }
+}
+

--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -18,6 +18,7 @@ using Hangfire;
 using Hangfire.MemoryStorage;
 using Dekofar.HyperConnect.Infrastructure.Jobs;
 using Microsoft.AspNetCore.Authorization;
+using Dekofar.API.Hubs;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -80,6 +81,8 @@ builder.Services.AddControllers()
         options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
     });
 
+builder.Services.AddSignalR();
+
 // 📘 Swagger + JWT Destekli Dokümantasyon
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
@@ -132,6 +135,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.UseHangfireDashboard();
 app.MapControllers();
+app.MapHub<LiveChatHub>("/chatHub");
 
 // 🚀 Seed default roles and admin user
 await SeedData.SeedDefaultsAsync(app.Services);


### PR DESCRIPTION
## Summary
- add LiveChatHub for real-time user messaging and presence tracking
- register SignalR hub and services
- allow JWT tokens from query for SignalR connections

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688e3a65135c83268215143f59f4d505