### PR TITLE
Add user profile stats endpoint

### DIFF
--- a/Dekofar.HyperConnect.Application/Interfaces/IUserService.cs
+++ b/Dekofar.HyperConnect.Application/Interfaces/IUserService.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Users.DTOs;
+
+namespace Dekofar.HyperConnect.Application.Interfaces
+{
+    public interface IUserService
+    {
+        Task<UserProfileDto?> GetProfileWithStatsAsync(Guid userId);
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/DTOs/UserProfileDto.cs
+++ b/Dekofar.HyperConnect.Application/Users/DTOs/UserProfileDto.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.Users.DTOs
+{
+    public class UserProfileDto
+    {
+        public Guid Id { get; set; }
+        public string FullName { get; set; } = default!;
+        public string? AvatarUrl { get; set; }
+        public string Email { get; set; } = default!;
+        public int UnreadMessageCount { get; set; }
+        public DateTime? LastMessageAt { get; set; }
+        public DateTime? LastSupportInteractionAt { get; set; }
+        public bool IsOnline { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -96,6 +96,7 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
 
             // 🔑 Token servisi
             services.AddScoped<ITokenService, TokenService>();
+            services.AddScoped<IUserService, UserService>();
 
             // ✅ MediatR
             services.AddMediatR(cfg =>

--- a/Dekofar.HyperConnect.Infrastructure/Services/UserService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/UserService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Dekofar.HyperConnect.Application.Users.DTOs;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    public class UserService : IUserService
+    {
+        private readonly IApplicationDbContext _dbContext;
+
+        public UserService(IApplicationDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+
+        public async Task<UserProfileDto?> GetProfileWithStatsAsync(Guid userId)
+        {
+            var user = await _dbContext.Users
+                .Where(u => u.Id == userId)
+                .Select(u => new UserProfileDto
+                {
+                    Id = u.Id,
+                    FullName = u.FullName ?? string.Empty,
+                    Email = u.Email!,
+                    AvatarUrl = u.AvatarUrl,
+                    UnreadMessageCount = _dbContext.UserMessages.Count(m => m.ReceiverId == u.Id && !m.IsRead),
+                    LastMessageAt = _dbContext.UserMessages
+                        .Where(m => m.SenderId == u.Id || m.ReceiverId == u.Id)
+                        .OrderByDescending(m => m.SentAt)
+                        .Select(m => m.SentAt)
+                        .FirstOrDefault(),
+                    LastSupportInteractionAt = _dbContext.SupportTickets
+                        .Where(t => t.CreatedByUserId == u.Id || t.AssignedUserId == u.Id)
+                        .OrderByDescending(t => t.LastUpdatedAt)
+                        .Select(t => t.LastUpdatedAt)
+                        .FirstOrDefault(),
+                    IsOnline = u.IsOnline
+                })
+                .FirstOrDefaultAsync();
+
+            return user;
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Authorization/ClaimsPrincipalExtensions.cs
+++ b/dekofar-hyperconnect-api/Authorization/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Security.Claims;
+
+namespace Dekofar.API.Authorization
+{
+    public static class ClaimsPrincipalExtensions
+    {
+        public static Guid? GetUserId(this ClaimsPrincipal user)
+        {
+            var id = user.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (Guid.TryParse(id, out var guid))
+            {
+                return guid;
+            }
+            return null;
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Dekofar.HyperConnect.Application.Users.Commands;
 using Dekofar.HyperConnect.Application.Users.DTOs;
 using Dekofar.HyperConnect.Application.Users.Queries;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Dekofar.API.Authorization;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -19,11 +21,13 @@ namespace Dekofar.API.Controllers
     {
         // MediatR aracısı
         private readonly IMediator _mediator;
+        private readonly IUserService _userService;
 
         // MediatR bağımlılığını alan kurucu
-        public UsersController(IMediator mediator)
+        public UsersController(IMediator mediator, IUserService userService)
         {
             _mediator = mediator;
+            _userService = userService;
         }
 
         // Sistemdeki tüm kullanıcıları döner
@@ -61,6 +65,16 @@ namespace Dekofar.API.Controllers
 
             var url = await _mediator.Send(new UploadProfileImageCommand { UserId = id, File = file });
             return Ok(new { avatarUrl = url });
+        }
+
+        [HttpGet("me/stats")]
+        [Authorize]
+        public async Task<IActionResult> GetMyProfileWithStats()
+        {
+            var userId = User.GetUserId();
+            if (userId == null) return Unauthorized();
+            var profile = await _userService.GetProfileWithStatsAsync(userId.Value);
+            return Ok(profile);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add UserProfileDto with unread message and support stats
- implement UserService to gather profile stats
- expose `GET /api/users/me/stats` endpoint using new service

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688e41f6c33c8326afd6b4f40818fb1b