### PR TITLE
Add profile summary endpoint with support metrics

### DIFF
--- a/Dekofar.HyperConnect.Application/Interfaces/IUserService.cs
+++ b/Dekofar.HyperConnect.Application/Interfaces/IUserService.cs
@@ -7,5 +7,6 @@ namespace Dekofar.HyperConnect.Application.Interfaces
     public interface IUserService
     {
         Task<UserProfileDto?> GetProfileWithStatsAsync(Guid userId);
+        Task<ProfileSummaryDto?> GetProfileSummaryAsync(Guid userId);
     }
 }

--- a/Dekofar.HyperConnect.Application/Users/DTOs/ProfileSummaryDto.cs
+++ b/Dekofar.HyperConnect.Application/Users/DTOs/ProfileSummaryDto.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.Users.DTOs
+{
+    public class ProfileSummaryDto
+    {
+        public string FullName { get; set; } = default!;
+        public string? AvatarUrl { get; set; }
+        public DateTime JoinedAt { get; set; }
+
+        public int TotalSupportTickets { get; set; }
+        public int OpenSupportTickets { get; set; }
+        public int ClosedSupportTickets { get; set; }
+        public DateTime? LastSupportActivityAt { get; set; }
+
+        public int TotalMessagesSent { get; set; }
+        public int UnreadMessagesCount { get; set; }
+        public DateTime? LastMessageAt { get; set; }
+
+        public decimal TotalSalesAmount { get; set; }
+        public decimal TotalCommission { get; set; }
+
+        public string[] Roles { get; set; } = Array.Empty<string>();
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Dekofar.Domain.Entities
 {
@@ -23,5 +24,24 @@ namespace Dekofar.Domain.Entities
         public DateTime? LastMessageDate { get; set; }
         public DateTime? LastSupportActivity { get; set; }
 
+        [NotMapped]
+        public int TotalSupportTickets
+        {
+            get => TotalSupportRequestCount;
+            set => TotalSupportRequestCount = value;
+        }
+
+        [NotMapped]
+        public int OpenSupportTickets { get; set; }
+
+        [NotMapped]
+        public int ClosedSupportTickets { get; set; }
+
+        [NotMapped]
+        public DateTime? LastSupportActivityAt
+        {
+            get => LastSupportActivity;
+            set => LastSupportActivity = value;
+        }
     }
 }

--- a/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
@@ -76,5 +76,16 @@ namespace Dekofar.API.Controllers
             var profile = await _userService.GetProfileWithStatsAsync(userId.Value);
             return Ok(profile);
         }
+
+        [HttpGet("me/summary")]
+        [Authorize]
+        public async Task<ActionResult<ProfileSummaryDto>> GetProfileSummary()
+        {
+            var userId = User.GetUserId();
+            if (userId == null) return Unauthorized();
+            var summary = await _userService.GetProfileSummaryAsync(userId.Value);
+            if (summary == null) return NotFound();
+            return Ok(summary);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add ProfileSummaryDto and service method to aggregate support ticket, messaging, order, commission, and role metrics
- expose GET /api/Users/me/summary endpoint for profile overview
- extend ApplicationUser with non-mapped support ticket counters

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688e487049e88326bc319187579d31aa