### PR TITLE
Add user sales and commission tracking

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -15,6 +15,8 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<ManualOrder> ManualOrders { get; }
         DbSet<ManualOrderItem> ManualOrderItems { get; }
         DbSet<OrderCommission> OrderCommissions { get; }
+        DbSet<Order> Orders { get; }
+        DbSet<Commission> Commissions { get; }
         DbSet<Discount> Discounts { get; }
         DbSet<Note> Notes { get; }
         DbSet<AuditLog> AuditLogs { get; }

--- a/Dekofar.HyperConnect.Application/Interfaces/IUserService.cs
+++ b/Dekofar.HyperConnect.Application/Interfaces/IUserService.cs
@@ -8,5 +8,6 @@ namespace Dekofar.HyperConnect.Application.Interfaces
     {
         Task<UserProfileDto?> GetProfileWithStatsAsync(Guid userId);
         Task<ProfileSummaryDto?> GetProfileSummaryAsync(Guid userId);
+        Task<SalesSummaryDto?> GetSalesSummaryAsync(Guid userId);
     }
 }

--- a/Dekofar.HyperConnect.Application/Users/DTOs/SalesSummaryDto.cs
+++ b/Dekofar.HyperConnect.Application/Users/DTOs/SalesSummaryDto.cs
@@ -1,0 +1,10 @@
+namespace Dekofar.HyperConnect.Application.Users.DTOs
+{
+    public class SalesSummaryDto
+    {
+        public decimal TotalSalesAmount { get; set; }
+        public decimal TotalCommissionAmount { get; set; }
+        public int OrdersCount { get; set; }
+        public int CommissionCount { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Identity;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using Dekofar.HyperConnect.Domain.Entities;
 
 namespace Dekofar.Domain.Entities
 {
@@ -43,5 +45,8 @@ namespace Dekofar.Domain.Entities
             get => LastSupportActivity;
             set => LastSupportActivity = value;
         }
+
+        public ICollection<Order> Orders { get; set; } = new List<Order>();
+        public ICollection<Commission> Commissions { get; set; } = new List<Commission>();
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/Commission.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/Commission.cs
@@ -1,0 +1,20 @@
+using System;
+using Dekofar.Domain.Entities;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class Commission
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public ApplicationUser User { get; set; } = default!;
+
+        public decimal Amount { get; set; }
+        public DateTime CreatedAt { get; set; }
+
+        public Guid? OrderId { get; set; }
+        public Order? Order { get; set; }
+
+        public string? Description { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/Order.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/Order.cs
@@ -1,0 +1,17 @@
+using System;
+using Dekofar.Domain.Entities;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class Order
+    {
+        public Guid Id { get; set; }
+        public DateTime CreatedAt { get; set; }
+        public decimal TotalAmount { get; set; }
+
+        public Guid? SellerId { get; set; }
+        public ApplicationUser? Seller { get; set; }
+
+        // Optional: integration with other systems could go here
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using System;
+using DomainOrder = Dekofar.HyperConnect.Domain.Entities.Order;
+using DomainCommission = Dekofar.HyperConnect.Domain.Entities.Commission;
 
 namespace Dekofar.HyperConnect.Infrastructure.Persistence
 {
@@ -25,6 +27,8 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<ManualOrder> ManualOrders => Set<ManualOrder>();
         public DbSet<ManualOrderItem> ManualOrderItems => Set<ManualOrderItem>();
         public DbSet<OrderCommission> OrderCommissions => Set<OrderCommission>();
+        public DbSet<DomainOrder> Orders => Set<DomainOrder>();
+        public DbSet<DomainCommission> Commissions => Set<DomainCommission>();
         public DbSet<Discount> Discounts => Set<Discount>();
         public DbSet<Note> Notes => Set<Note>();
         public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
@@ -109,6 +113,32 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 entity.Property(e => e.CommissionRate).HasColumnType("decimal(18,4)");
                 entity.Property(e => e.EarnedAmount).HasColumnType("decimal(18,2)");
                 entity.Property(e => e.CreatedAt).IsRequired();
+            });
+
+            builder.Entity<DomainOrder>(entity =>
+            {
+                entity.ToTable("Orders");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.TotalAmount).HasColumnType("decimal(18,2)");
+                entity.HasOne(e => e.Seller)
+                      .WithMany(u => u.Orders)
+                      .HasForeignKey(e => e.SellerId)
+                      .OnDelete(DeleteBehavior.SetNull);
+            });
+
+            builder.Entity<DomainCommission>(entity =>
+            {
+                entity.ToTable("Commissions");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Amount).HasColumnType("decimal(18,2)");
+                entity.HasOne(c => c.User)
+                      .WithMany(u => u.Commissions)
+                      .HasForeignKey(c => c.UserId)
+                      .OnDelete(DeleteBehavior.Cascade);
+                entity.HasOne(c => c.Order)
+                      .WithMany()
+                      .HasForeignKey(c => c.OrderId)
+                      .OnDelete(DeleteBehavior.SetNull);
             });
 
             builder.Entity<Note>(entity =>

--- a/Dekofar.HyperConnect.Infrastructure/Services/UserService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/UserService.cs
@@ -85,5 +85,25 @@ namespace Dekofar.HyperConnect.Infrastructure.Services
 
             return summary;
         }
+
+        public async Task<SalesSummaryDto?> GetSalesSummaryAsync(Guid userId)
+        {
+            var summary = await _dbContext.Users
+                .Where(u => u.Id == userId)
+                .Select(u => new SalesSummaryDto
+                {
+                    TotalSalesAmount = _dbContext.Orders
+                        .Where(o => o.SellerId == u.Id)
+                        .Sum(o => (decimal?)o.TotalAmount) ?? 0,
+                    TotalCommissionAmount = _dbContext.Commissions
+                        .Where(c => c.UserId == u.Id)
+                        .Sum(c => (decimal?)c.Amount) ?? 0,
+                    OrdersCount = _dbContext.Orders.Count(o => o.SellerId == u.Id),
+                    CommissionCount = _dbContext.Commissions.Count(c => c.UserId == u.Id)
+                })
+                .FirstOrDefaultAsync();
+
+            return summary;
+        }
     }
 }

--- a/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
@@ -87,5 +87,14 @@ namespace Dekofar.API.Controllers
             if (summary == null) return NotFound();
             return Ok(summary);
         }
+
+        [HttpGet("{id:guid}/sales-summary")]
+        [Authorize]
+        public async Task<ActionResult<SalesSummaryDto>> GetSalesSummary(Guid id)
+        {
+            var summary = await _userService.GetSalesSummaryAsync(id);
+            if (summary == null) return NotFound();
+            return Ok(summary);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Order and Commission entities and link them to ApplicationUser
- expose Orders and Commissions in the EF Core context
- provide sales summary DTO, service, and API endpoint for user totals

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_688e4ad59ee0832685ba49a95970bafc