### PR TITLE
Add admin dashboard metrics endpoints

### DIFF
--- a/Dekofar.HyperConnect.Application/Dashboard/DTOs/DashboardSummaryDto.cs
+++ b/Dekofar.HyperConnect.Application/Dashboard/DTOs/DashboardSummaryDto.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace Dekofar.HyperConnect.Application.Dashboard.DTOs
+{
+    public class DashboardSummaryDto
+    {
+        public int TotalUsers { get; set; }
+        public int ActiveUsers { get; set; }
+        public decimal TotalSales { get; set; }
+        public int TotalOrders { get; set; }
+        public int TotalSupportTickets { get; set; }
+        public int OpenTickets { get; set; }
+        public decimal TotalCommissionPaid { get; set; }
+        public List<TopSellerDto> TopSellers { get; set; } = new();
+    }
+}

--- a/Dekofar.HyperConnect.Application/Dashboard/DTOs/SalesOverTimeDto.cs
+++ b/Dekofar.HyperConnect.Application/Dashboard/DTOs/SalesOverTimeDto.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.Dashboard.DTOs
+{
+    public class SalesOverTimeDto
+    {
+        public DateTime Date { get; set; }
+        public decimal TotalSales { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Dashboard/DTOs/TicketActivityDto.cs
+++ b/Dekofar.HyperConnect.Application/Dashboard/DTOs/TicketActivityDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.Dashboard.DTOs
+{
+    public class TicketActivityDto
+    {
+        public DateTime Date { get; set; }
+        public int Created { get; set; }
+        public int Resolved { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Dashboard/DTOs/TopProductDto.cs
+++ b/Dekofar.HyperConnect.Application/Dashboard/DTOs/TopProductDto.cs
@@ -1,0 +1,9 @@
+namespace Dekofar.HyperConnect.Application.Dashboard.DTOs
+{
+    public class TopProductDto
+    {
+        public string ProductName { get; set; } = default!;
+        public int UnitsSold { get; set; }
+        public decimal Revenue { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Dashboard/DTOs/TopSellerDto.cs
+++ b/Dekofar.HyperConnect.Application/Dashboard/DTOs/TopSellerDto.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.Dashboard.DTOs
+{
+    public class TopSellerDto
+    {
+        public Guid UserId { get; set; }
+        public string? FullName { get; set; }
+        public decimal TotalSales { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Interfaces/IDashboardService.cs
+++ b/Dekofar.HyperConnect.Application/Interfaces/IDashboardService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Dashboard.DTOs;
+
+namespace Dekofar.HyperConnect.Application.Interfaces
+{
+    public interface IDashboardService
+    {
+        Task<DashboardSummaryDto> GetSummaryAsync();
+        Task<List<SalesOverTimeDto>> GetSalesOverTimeAsync(int days);
+        Task<List<TopProductDto>> GetTopProductsAsync(int limit);
+        Task<List<TicketActivityDto>> GetTicketActivityAsync(int days);
+    }
+}

--- a/Dekofar.HyperConnect.Application/Services/DashboardService.cs
+++ b/Dekofar.HyperConnect.Application/Services/DashboardService.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.Dashboard.DTOs;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.Services
+{
+    public class DashboardService : IDashboardService
+    {
+        private readonly IApplicationDbContext _context;
+
+        public DashboardService(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<DashboardSummaryDto> GetSummaryAsync()
+        {
+            var now = DateTime.UtcNow;
+            var activeThreshold = now.AddDays(-30);
+
+            var totalUsersTask = _context.Users.CountAsync();
+            var activeUsersTask = _context.Users.CountAsync(u => u.LastSeen != null && u.LastSeen >= activeThreshold);
+            var orderSalesTask = _context.Orders.SumAsync(o => (decimal?)o.TotalAmount) ;
+            var manualSalesTask = _context.ManualOrders.SumAsync(o => (decimal?)o.TotalAmount) ;
+            var orderCountTask = _context.Orders.CountAsync();
+            var manualOrderCountTask = _context.ManualOrders.CountAsync();
+            var totalSupportTicketsTask = _context.SupportTickets.CountAsync();
+            var openTicketsTask = _context.SupportTickets.CountAsync(t => t.Status != SupportTicketStatus.Closed);
+            var commissionPaidTask = _context.Commissions.SumAsync(c => (decimal?)c.Amount);
+
+            await Task.WhenAll(totalUsersTask, activeUsersTask, orderSalesTask, manualSalesTask,
+                orderCountTask, manualOrderCountTask, totalSupportTicketsTask, openTicketsTask, commissionPaidTask);
+
+            var topSellers = await _context.Orders
+                .Where(o => o.SellerId != null)
+                .Include(o => o.Seller)
+                .GroupBy(o => new { o.SellerId, o.Seller.FullName })
+                .Select(g => new TopSellerDto
+                {
+                    UserId = g.Key.SellerId!.Value,
+                    FullName = g.Key.FullName,
+                    TotalSales = g.Sum(o => o.TotalAmount)
+                })
+                .OrderByDescending(x => x.TotalSales)
+                .Take(5)
+                .ToListAsync();
+
+            return new DashboardSummaryDto
+            {
+                TotalUsers = totalUsersTask.Result,
+                ActiveUsers = activeUsersTask.Result,
+                TotalSales = (orderSalesTask.Result ?? 0) + (manualSalesTask.Result ?? 0),
+                TotalOrders = orderCountTask.Result + manualOrderCountTask.Result,
+                TotalSupportTickets = totalSupportTicketsTask.Result,
+                OpenTickets = openTicketsTask.Result,
+                TotalCommissionPaid = commissionPaidTask.Result ?? 0,
+                TopSellers = topSellers
+            };
+        }
+
+        public async Task<List<SalesOverTimeDto>> GetSalesOverTimeAsync(int days)
+        {
+            var startDate = DateTime.UtcNow.Date.AddDays(-days + 1);
+
+            var orderSalesTask = _context.Orders
+                .Where(o => o.CreatedAt >= startDate)
+                .GroupBy(o => o.CreatedAt.Date)
+                .Select(g => new { Date = g.Key, Total = g.Sum(x => x.TotalAmount) })
+                .ToListAsync();
+
+            var manualSalesTask = _context.ManualOrders
+                .Where(o => o.CreatedAt >= startDate)
+                .GroupBy(o => o.CreatedAt.Date)
+                .Select(g => new { Date = g.Key, Total = g.Sum(x => x.TotalAmount) })
+                .ToListAsync();
+
+            await Task.WhenAll(orderSalesTask, manualSalesTask);
+
+            var dict = orderSalesTask.Result.Concat(manualSalesTask.Result)
+                .GroupBy(x => x.Date)
+                .ToDictionary(g => g.Key, g => g.Sum(x => x.Total));
+
+            var result = new List<SalesOverTimeDto>();
+            for (int i = 0; i < days; i++)
+            {
+                var date = startDate.AddDays(i);
+                dict.TryGetValue(date, out var total);
+                result.Add(new SalesOverTimeDto { Date = date, TotalSales = total });
+            }
+
+            return result;
+        }
+
+        public async Task<List<TopProductDto>> GetTopProductsAsync(int limit)
+        {
+            var products = await _context.ManualOrderItems
+                .GroupBy(i => i.ProductName)
+                .Select(g => new TopProductDto
+                {
+                    ProductName = g.Key,
+                    UnitsSold = g.Sum(i => i.Quantity),
+                    Revenue = g.Sum(i => i.Total)
+                })
+                .OrderByDescending(p => p.UnitsSold)
+                .Take(limit)
+                .ToListAsync();
+
+            return products;
+        }
+
+        public async Task<List<TicketActivityDto>> GetTicketActivityAsync(int days)
+        {
+            var startDate = DateTime.UtcNow.Date.AddDays(-days + 1);
+
+            var createdTask = _context.SupportTickets
+                .Where(t => t.CreatedAt >= startDate)
+                .GroupBy(t => t.CreatedAt.Date)
+                .Select(g => new { Date = g.Key, Count = g.Count() })
+                .ToListAsync();
+
+            var resolvedTask = _context.SupportTickets
+                .Where(t => t.Status == SupportTicketStatus.Closed && t.LastUpdatedAt >= startDate)
+                .GroupBy(t => t.LastUpdatedAt.Date)
+                .Select(g => new { Date = g.Key, Count = g.Count() })
+                .ToListAsync();
+
+            await Task.WhenAll(createdTask, resolvedTask);
+
+            var createdDict = createdTask.Result.ToDictionary(x => x.Date, x => x.Count);
+            var resolvedDict = resolvedTask.Result.ToDictionary(x => x.Date, x => x.Count);
+
+            var result = new List<TicketActivityDto>();
+            for (int i = 0; i < days; i++)
+            {
+                var date = startDate.AddDays(i);
+                createdDict.TryGetValue(date, out var created);
+                resolvedDict.TryGetValue(date, out var resolved);
+                result.Add(new TicketActivityDto { Date = date, Created = created, Resolved = resolved });
+            }
+
+            return result;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Tests/Dekofar.HyperConnect.Tests.csproj
+++ b/Dekofar.HyperConnect.Tests/Dekofar.HyperConnect.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.4" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Dekofar.HyperConnect.Application\Dekofar.HyperConnect.Application.csproj" />
+    <ProjectReference Include="..\Dekofar.HyperConnect.Infrastructure\Dekofar.HyperConnect.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/Dekofar.HyperConnect.Tests/Services/DashboardServiceTests.cs
+++ b/Dekofar.HyperConnect.Tests/Services/DashboardServiceTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Services;
+using Dekofar.HyperConnect.Domain.Entities;
+using Dekofar.HyperConnect.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Dekofar.HyperConnect.Tests.Services
+{
+    public class DashboardServiceTests
+    {
+        private ApplicationDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+                .UseInMemoryDatabase(Guid.NewGuid().ToString())
+                .Options;
+            return new ApplicationDbContext(options);
+        }
+
+        [Fact]
+        public async Task GetSummaryAsync_ReturnsCorrectCounts()
+        {
+            using var context = CreateContext();
+            context.Users.Add(new Dekofar.Domain.Entities.ApplicationUser { Id = Guid.NewGuid(), LastSeen = DateTime.UtcNow });
+            context.Orders.Add(new Dekofar.HyperConnect.Domain.Entities.Order { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, TotalAmount = 100 });
+            context.SupportTickets.Add(new SupportTicket { Id = Guid.NewGuid(), Title = "t", Description = "d", CreatedByUserId = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, LastUpdatedAt = DateTime.UtcNow, Status = SupportTicketStatus.Open });
+            context.Commissions.Add(new Commission { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), Amount = 10, CreatedAt = DateTime.UtcNow });
+            await context.SaveChangesAsync();
+
+            var service = new DashboardService(context);
+            var summary = await service.GetSummaryAsync();
+
+            Assert.Equal(1, summary.TotalUsers);
+            Assert.Equal(1, summary.ActiveUsers);
+            Assert.Equal(100, summary.TotalSales);
+            Assert.Equal(1, summary.TotalOrders);
+            Assert.Equal(1, summary.TotalSupportTickets);
+            Assert.Equal(1, summary.OpenTickets);
+            Assert.Equal(10, summary.TotalCommissionPaid);
+        }
+    }
+}

--- a/dekofar-hyperconnect-api.sln
+++ b/dekofar-hyperconnect-api.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekofar.HyperConnect.Shared
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekofar.HyperConnect.Application", "Dekofar.HyperConnect.Application\Dekofar.HyperConnect.Application.csproj", "{226CFB77-E4FF-4F3F-9E92-0BFD8556883C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dekofar.HyperConnect.Tests", "Dekofar.HyperConnect.Tests\\Dekofar.HyperConnect.Tests.csproj", "{9C558325-3458-4EFD-BECE-4AB614768021}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{226CFB77-E4FF-4F3F-9E92-0BFD8556883C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{226CFB77-E4FF-4F3F-9E92-0BFD8556883C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{226CFB77-E4FF-4F3F-9E92-0BFD8556883C}.Release|Any CPU.Build.0 = Release|Any CPU
+                {9C558325-3458-4EFD-BECE-4AB614768021}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9C558325-3458-4EFD-BECE-4AB614768021}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9C558325-3458-4EFD-BECE-4AB614768021}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9C558325-3458-4EFD-BECE-4AB614768021}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/dekofar-hyperconnect-api/Controllers/Admin/DashboardController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Admin/DashboardController.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Dashboard.DTOs;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dekofar.API.Controllers.Admin
+{
+    [ApiController]
+    [Route("api/admin/dashboard")]
+    [Authorize(Roles = "Admin")]
+    public class DashboardController : ControllerBase
+    {
+        private readonly IDashboardService _dashboardService;
+
+        public DashboardController(IDashboardService dashboardService)
+        {
+            _dashboardService = dashboardService;
+        }
+
+        /// <summary>
+        /// Gets summary metrics for the dashboard.
+        /// </summary>
+        [HttpGet("summary")]
+        [ProducesResponseType(typeof(DashboardSummaryDto), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetSummary()
+        {
+            var summary = await _dashboardService.GetSummaryAsync();
+            return Ok(summary);
+        }
+
+        /// <summary>
+        /// Gets sales totals grouped by date within a range.
+        /// </summary>
+        [HttpGet("sales-over-time")]
+        [ProducesResponseType(typeof(List<SalesOverTimeDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetSalesOverTime([FromQuery] string range = "7d")
+        {
+            var days = range switch
+            {
+                "30d" => 30,
+                "90d" => 90,
+                _ => 7
+            };
+            var data = await _dashboardService.GetSalesOverTimeAsync(days);
+            return Ok(data);
+        }
+
+        /// <summary>
+        /// Gets the most sold products.
+        /// </summary>
+        [HttpGet("top-products")]
+        [ProducesResponseType(typeof(List<TopProductDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetTopProducts([FromQuery] int limit = 5)
+        {
+            var data = await _dashboardService.GetTopProductsAsync(limit);
+            return Ok(data);
+        }
+
+        /// <summary>
+        /// Gets support ticket activity over time.
+        /// </summary>
+        [HttpGet("ticket-activity")]
+        [ProducesResponseType(typeof(List<TicketActivityDto>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> GetTicketActivity([FromQuery] string range = "30d")
+        {
+            var days = range switch
+            {
+                "7d" => 7,
+                "90d" => 90,
+                _ => 30
+            };
+            var data = await _dashboardService.GetTicketActivityAsync(days);
+            return Ok(data);
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -21,6 +21,8 @@ using Dekofar.HyperConnect.Infrastructure.Jobs;
 using Microsoft.AspNetCore.Authorization;
 using Dekofar.API.Hubs;
 using Dekofar.API.Services;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Dekofar.HyperConnect.Application.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -75,6 +77,7 @@ builder.Services.AddHangfireServer();
 builder.Services.AddScoped<INetGsmSmsService, NetGsmSmsService>();
 builder.Services.AddHttpClient<IShopifyService, ShopifyService>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<IDashboardService, DashboardService>();
 
 // 📡 Controller & JSON Ayarları
 builder.Services.AddControllers()


### PR DESCRIPTION
## Summary
- build DashboardService with summary, sales trends, top products, and ticket activity logic
- expose admin-only dashboard endpoints for summary, sales-over-time, top products, and ticket activity
- wire service into DI and add sample DashboardService unit test

## Testing
- `dotnet test` *(fails: AutoMapper assembly not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e5dc86b708326a68eb568c721be55