### PR TITLE
Align models and services

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -1,4 +1,3 @@
-using Dekofar.Domain.Entities;
 using Dekofar.HyperConnect.Domain.Entities;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;

--- a/Dekofar.HyperConnect.Application/SupportTickets/DTOs/SupportTicketDto.cs
+++ b/Dekofar.HyperConnect.Application/SupportTickets/DTOs/SupportTicketDto.cs
@@ -18,5 +18,6 @@ namespace Dekofar.HyperConnect.Application.SupportTickets.DTOs
         public string? FilePath { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime LastUpdatedAt { get; set; }
+        public int UnreadReplyCount { get; set; }
     }
 }

--- a/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetMyTicketsQueryHandler.cs
+++ b/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetMyTicketsQueryHandler.cs
@@ -42,7 +42,8 @@ namespace Dekofar.HyperConnect.Application.SupportTickets.Queries
                     DueDate = t.DueDate,
                     FilePath = t.FilePath,
                     CreatedAt = t.CreatedAt,
-                    LastUpdatedAt = t.LastUpdatedAt
+                    LastUpdatedAt = t.LastUpdatedAt,
+                    UnreadReplyCount = t.UnreadReplyCount
                 })
                 .ToListAsync(cancellationToken);
         }

--- a/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetTicketByIdQueryHandler.cs
+++ b/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetTicketByIdQueryHandler.cs
@@ -38,7 +38,8 @@ namespace Dekofar.HyperConnect.Application.SupportTickets.Queries
                 DueDate = ticket.DueDate,
                 FilePath = ticket.FilePath,
                 CreatedAt = ticket.CreatedAt,
-                LastUpdatedAt = ticket.LastUpdatedAt
+                LastUpdatedAt = ticket.LastUpdatedAt,
+                UnreadReplyCount = ticket.UnreadReplyCount
             };
         }
     }

--- a/Dekofar.HyperConnect.Application/Users/Commands/AssignRoles/AssignRolesCommandHandler.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/AssignRoles/AssignRolesCommandHandler.cs
@@ -1,4 +1,4 @@
-using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using System;

--- a/Dekofar.HyperConnect.Application/Users/Commands/AssignRolesToUserCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/AssignRolesToUserCommand.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Domain.Entities;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 

--- a/Dekofar.HyperConnect.Application/Users/Commands/UploadProfileImageCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/UploadProfileImageCommand.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Domain.Entities;
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using MediatR;
 using Microsoft.AspNetCore.Http;

--- a/Dekofar.HyperConnect.Application/Users/DTOs/ProfileSummaryDto.cs
+++ b/Dekofar.HyperConnect.Application/Users/DTOs/ProfileSummaryDto.cs
@@ -14,8 +14,8 @@ namespace Dekofar.HyperConnect.Application.Users.DTOs
         public DateTime? LastSupportActivityAt { get; set; }
 
         public int TotalMessagesSent { get; set; }
-        public int UnreadMessagesCount { get; set; }
-        public DateTime? LastMessageAt { get; set; }
+        public int UnreadMessageCount { get; set; }
+        public DateTime? LastMessageDate { get; set; }
 
         public decimal TotalSalesAmount { get; set; }
         public decimal TotalCommission { get; set; }

--- a/Dekofar.HyperConnect.Application/Users/DTOs/UserProfileDto.cs
+++ b/Dekofar.HyperConnect.Application/Users/DTOs/UserProfileDto.cs
@@ -9,8 +9,8 @@ namespace Dekofar.HyperConnect.Application.Users.DTOs
         public string? AvatarUrl { get; set; }
         public string Email { get; set; } = default!;
         public int UnreadMessageCount { get; set; }
-        public DateTime? LastMessageAt { get; set; }
-        public DateTime? LastSupportInteractionAt { get; set; }
+        public DateTime? LastMessageDate { get; set; }
+        public DateTime? LastSupportActivityAt { get; set; }
         public bool IsOnline { get; set; }
     }
 }

--- a/Dekofar.HyperConnect.Application/Users/Queries/GetAllUsersWithRolesQuery.cs
+++ b/Dekofar.HyperConnect.Application/Users/Queries/GetAllUsersWithRolesQuery.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Domain.Entities;
 using Dekofar.HyperConnect.Application.Users.DTOs;
 using MediatR;
 using Microsoft.AspNetCore.Identity;

--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -2,9 +2,8 @@ using Microsoft.AspNetCore.Identity;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using Dekofar.HyperConnect.Domain.Entities;
 
-namespace Dekofar.Domain.Entities
+namespace Dekofar.HyperConnect.Domain.Entities
 {
     public class ApplicationUser : IdentityUser<Guid>
     {

--- a/Dekofar.HyperConnect.Domain/Entities/Commission.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/Commission.cs
@@ -1,5 +1,4 @@
 using System;
-using Dekofar.Domain.Entities;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {

--- a/Dekofar.HyperConnect.Domain/Entities/Order.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/Order.cs
@@ -1,5 +1,4 @@
 using System;
-using Dekofar.Domain.Entities;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {

--- a/Dekofar.HyperConnect.Domain/Entities/SupportTicketReply.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/SupportTicketReply.cs
@@ -1,5 +1,4 @@
 using System;
-using Dekofar.Domain.Entities;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {

--- a/Dekofar.HyperConnect.Domain/Entities/UserMessage.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/UserMessage.cs
@@ -1,5 +1,4 @@
 using System;
-using Dekofar.Domain.Entities;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802130839_dfsdfsfsfcls.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802130839_dfsdfsfsfcls.Designer.cs
@@ -25,7 +25,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -716,7 +716,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -725,7 +725,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -740,7 +740,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -749,7 +749,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802130847_gfgdg.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802130847_gfgdg.Designer.cs
@@ -25,7 +25,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -716,7 +716,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -725,7 +725,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -740,7 +740,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -749,7 +749,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802155824_ExtendUserProfile.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802155824_ExtendUserProfile.Designer.cs
@@ -25,7 +25,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -743,7 +743,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -752,7 +752,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -767,7 +767,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -776,7 +776,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802161302_AddUserMessages.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802161302_AddUserMessages.Designer.cs
@@ -25,7 +25,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -770,13 +770,13 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.UserMessage", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Receiver")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Receiver")
                         .WithMany()
                         .HasForeignKey("ReceiverId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Sender")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Sender")
                         .WithMany()
                         .HasForeignKey("SenderId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -798,7 +798,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -807,7 +807,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -822,7 +822,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -831,7 +831,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802171328_AddMessageFileMetadata.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802171328_AddMessageFileMetadata.Designer.cs
@@ -25,7 +25,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -776,13 +776,13 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.UserMessage", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Receiver")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Receiver")
                         .WithMany()
                         .HasForeignKey("ReceiverId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Sender")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Sender")
                         .WithMany()
                         .HasForeignKey("SenderId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -804,7 +804,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -813,7 +813,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -828,7 +828,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -837,7 +837,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802182521_AddSupportTicketReplies.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802182521_AddSupportTicketReplies.Designer.cs
@@ -25,7 +25,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -810,7 +810,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .HasForeignKey("OrderId")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "User")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "User")
                         .WithMany("Commissions")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -834,7 +834,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.Order", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Seller")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Seller")
                         .WithMany("Orders")
                         .HasForeignKey("SellerId")
                         .OnDelete(DeleteBehavior.SetNull);
@@ -893,7 +893,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "User")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -906,13 +906,13 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.UserMessage", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Receiver")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Receiver")
                         .WithMany()
                         .HasForeignKey("ReceiverId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Sender")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Sender")
                         .WithMany()
                         .HasForeignKey("SenderId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -934,7 +934,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -943,7 +943,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -958,7 +958,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -967,14 +967,14 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Navigation("Commissions");
 

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -22,7 +22,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
@@ -807,7 +807,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .HasForeignKey("OrderId")
                         .OnDelete(DeleteBehavior.SetNull);
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "User")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "User")
                         .WithMany("Commissions")
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -831,7 +831,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.Order", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Seller")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Seller")
                         .WithMany("Orders")
                         .HasForeignKey("SellerId")
                         .OnDelete(DeleteBehavior.SetNull);
@@ -890,7 +890,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "User")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "User")
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -903,13 +903,13 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.UserMessage", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Receiver")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Receiver")
                         .WithMany()
                         .HasForeignKey("ReceiverId")
                         .OnDelete(DeleteBehavior.Restrict)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", "Sender")
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", "Sender")
                         .WithMany()
                         .HasForeignKey("SenderId")
                         .OnDelete(DeleteBehavior.Restrict)
@@ -931,7 +931,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -940,7 +940,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -955,7 +955,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
@@ -964,14 +964,14 @@ namespace Dekofar.HyperConnect.Infrastructure.Migrations
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Dekofar.Domain.Entities.ApplicationUser", null)
+                    b.HasOne("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Dekofar.Domain.Entities.ApplicationUser", b =>
+            modelBuilder.Entity("Dekofar.HyperConnect.Domain.Entities.ApplicationUser", b =>
                 {
                     b.Navigation("Commissions");
 

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -1,5 +1,4 @@
-﻿using Dekofar.Domain.Entities;
-using Dekofar.HyperConnect.Application.Common.Interfaces;
+﻿using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Domain.Entities;
 using Dekofar.HyperConnect.Domain.Entities.Orders;
 using Microsoft.AspNetCore.Identity;

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -2,7 +2,6 @@
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Application.Interfaces;
 using Dekofar.HyperConnect.Domain.Entities;
-using Dekofar.Domain.Entities;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Dekofar.HyperConnect.Infrastructure.Services;
 using Dekofar.HyperConnect.Infrastructure.Jobs;

--- a/Dekofar.HyperConnect.Infrastructure/Services/SeedData.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/SeedData.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Dekofar.Domain.Entities;
 using Dekofar.HyperConnect.Domain.Entities;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Identity;

--- a/Dekofar.HyperConnect.Infrastructure/Services/UserService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/UserService.cs
@@ -29,12 +29,12 @@ namespace Dekofar.HyperConnect.Infrastructure.Services
                     Email = u.Email!,
                     AvatarUrl = u.AvatarUrl,
                     UnreadMessageCount = _dbContext.UserMessages.Count(m => m.ReceiverId == u.Id && !m.IsRead),
-                    LastMessageAt = _dbContext.UserMessages
+                    LastMessageDate = _dbContext.UserMessages
                         .Where(m => m.SenderId == u.Id || m.ReceiverId == u.Id)
                         .OrderByDescending(m => m.SentAt)
                         .Select(m => m.SentAt)
                         .FirstOrDefault(),
-                    LastSupportInteractionAt = _dbContext.SupportTickets
+                    LastSupportActivityAt = _dbContext.SupportTickets
                         .Where(t => t.CreatedByUserId == u.Id || t.AssignedUserId == u.Id)
                         .OrderByDescending(t => t.LastUpdatedAt)
                         .Select(t => t.LastUpdatedAt)
@@ -64,8 +64,8 @@ namespace Dekofar.HyperConnect.Infrastructure.Services
                         .Select(t => (DateTime?)t.LastUpdatedAt)
                         .FirstOrDefault(),
                     TotalMessagesSent = _dbContext.UserMessages.Count(m => m.SenderId == u.Id),
-                    UnreadMessagesCount = _dbContext.UserMessages.Count(m => m.ReceiverId == u.Id && !m.IsRead),
-                    LastMessageAt = _dbContext.UserMessages
+                    UnreadMessageCount = _dbContext.UserMessages.Count(m => m.ReceiverId == u.Id && !m.IsRead),
+                    LastMessageDate = _dbContext.UserMessages
                         .Where(m => m.SenderId == u.Id || m.ReceiverId == u.Id)
                         .OrderByDescending(m => m.SentAt)
                         .Select(m => (DateTime?)m.SentAt)

--- a/Dekofar.HyperConnect.Tests/Services/DashboardServiceTests.cs
+++ b/Dekofar.HyperConnect.Tests/Services/DashboardServiceTests.cs
@@ -22,7 +22,7 @@ namespace Dekofar.HyperConnect.Tests.Services
         public async Task GetSummaryAsync_ReturnsCorrectCounts()
         {
             using var context = CreateContext();
-            context.Users.Add(new Dekofar.Domain.Entities.ApplicationUser { Id = Guid.NewGuid(), LastSeen = DateTime.UtcNow });
+            context.Users.Add(new ApplicationUser { Id = Guid.NewGuid(), LastSeen = DateTime.UtcNow });
             context.Orders.Add(new Dekofar.HyperConnect.Domain.Entities.Order { Id = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, TotalAmount = 100 });
             context.SupportTickets.Add(new SupportTicket { Id = Guid.NewGuid(), Title = "t", Description = "d", CreatedByUserId = Guid.NewGuid(), CreatedAt = DateTime.UtcNow, LastUpdatedAt = DateTime.UtcNow, Status = SupportTicketStatus.Open });
             context.Commissions.Add(new Commission { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), Amount = 10, CreatedAt = DateTime.UtcNow });

--- a/dekofar-hyperconnect-api/Authorization/PermissionAuthorizationHandler.cs
+++ b/dekofar-hyperconnect-api/Authorization/PermissionAuthorizationHandler.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Dekofar.Domain.Entities;
+using Dekofar.HyperConnect.Domain.Entities;
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;

--- a/dekofar-hyperconnect-api/Controllers/Auth/AuthController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Auth/AuthController.cs
@@ -1,5 +1,4 @@
-﻿using Dekofar.Domain.Entities;
-using Dekofar.HyperConnect.Application.Auth;
+﻿using Dekofar.HyperConnect.Application.Auth;
 using Dekofar.HyperConnect.Application.Interfaces;
 using Dekofar.HyperConnect.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;

--- a/dekofar-hyperconnect-api/Hubs/LiveChatHub.cs
+++ b/dekofar-hyperconnect-api/Hubs/LiveChatHub.cs
@@ -3,7 +3,6 @@ using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Domain.Entities;
-using Dekofar.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 


### PR DESCRIPTION
## Summary
- expose `UnreadReplyCount` on support ticket DTOs and handlers
- harmonize user profile DTO names and update related service projections
- unify `ApplicationUser` namespace across solution

## Testing
- `dotnet build`
- `dotnet test` *(fails: An assembly specified in the application dependencies manifest was not found: AutoMapper 12.0.1)*

------
https://chatgpt.com/codex/tasks/task_e_688e63c07a34832688f35ca6edde8d0d