### PR TITLE
feat: add hashed pin support with audit timestamp

### DIFF
--- a/Dekofar.HyperConnect.Domain/Entities/AppUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/AppUser.cs
@@ -1,9 +1,20 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using System;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {
     public class AppUser : IdentityUser<Guid>
     {
         public string FullName { get; set; }
+
+        /// <summary>
+        ///     Stored hashed representation of the user's 4-digit PIN.
+        /// </summary>
+        public string? HashedPin { get; set; }
+
+        /// <summary>
+        ///     Timestamp of the last PIN update for auditing purposes.
+        /// </summary>
+        public DateTime? PinLastUpdatedAt { get; set; }
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -20,6 +20,11 @@ namespace Dekofar.HyperConnect.Domain.Entities
         /// </summary>
         public string? HashedPin { get; set; }
 
+        /// <summary>
+        ///     Timestamp when the user's PIN was last updated.
+        /// </summary>
+        public DateTime? PinLastUpdatedAt { get; set; }
+
         public DateTime MembershipDate { get; set; }
         public bool IsOnline { get; set; }
         public DateTime? LastSeen { get; set; }

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802194014_AddPinLastUpdatedAt.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802194014_AddPinLastUpdatedAt.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Dekofar.HyperConnect.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802194014_AddPinLastUpdatedAt")]
+    partial class AddPinLastUpdatedAt
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802194014_AddPinLastUpdatedAt.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802194014_AddPinLastUpdatedAt.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dekofar.HyperConnect.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPinLastUpdatedAt : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "UnreadReplyCount",
+                table: "SupportTickets",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "HashedPin",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "PinLastUpdatedAt",
+                table: "AspNetUsers",
+                type: "timestamp with time zone",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UnreadReplyCount",
+                table: "SupportTickets");
+
+            migrationBuilder.DropColumn(
+                name: "HashedPin",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "PinLastUpdatedAt",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Users/UsersController.cs
@@ -121,6 +121,7 @@ namespace Dekofar.API.Controllers
             if (user == null) return NotFound();
 
             user.HashedPin = _userManager.PasswordHasher.HashPassword(user, request.Pin);
+            user.PinLastUpdatedAt = DateTime.UtcNow;
             await _userManager.UpdateAsync(user);
             return Ok();
         }
@@ -152,6 +153,7 @@ namespace Dekofar.API.Controllers
             var user = await _userManager.FindByIdAsync(id.ToString());
             if (user == null) return NotFound();
             user.HashedPin = null;
+            user.PinLastUpdatedAt = null;
             await _userManager.UpdateAsync(user);
             return Ok();
         }


### PR DESCRIPTION
## Summary
- extend user entities with hashed PIN and audit timestamp
- update user PIN endpoints to store and clear update timestamp
- add EF migration for hashed PIN fields

## Testing
- `dotnet test` *(fails: AutoMapper assembly not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e68a2cdd0832688e354bb0350164e