### PR TITLE
Add PIN session locking endpoints

### DIFF
--- a/dekofar-hyperconnect-api/Controllers/Account/AccountController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Account/AccountController.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+
+namespace Dekofar.API.Controllers
+{
+    [ApiController]
+    [Route("api/account")]
+    [Authorize]
+    public class AccountController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly PasswordHasher<ApplicationUser> _passwordHasher = new();
+        private readonly IConfiguration _configuration;
+
+        public AccountController(UserManager<ApplicationUser> userManager, IConfiguration configuration)
+        {
+            _userManager = userManager;
+            _configuration = configuration;
+        }
+
+        [HttpPost("set-pin")]
+        public async Task<IActionResult> SetPin([FromBody] PinDto dto)
+        {
+            if (!ModelState.IsValid) return BadRequest(ModelState);
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null) return Unauthorized();
+
+            user.HashedPin = _passwordHasher.HashPassword(user, dto.Pin);
+            user.PinLastUpdatedAt = DateTime.UtcNow;
+            await _userManager.UpdateAsync(user);
+            return Ok();
+        }
+
+        [HttpPost("verify-pin")]
+        public async Task<IActionResult> VerifyPin([FromBody] PinDto dto)
+        {
+            if (!ModelState.IsValid) return BadRequest(ModelState);
+
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null || string.IsNullOrEmpty(user.HashedPin)) return Unauthorized();
+
+            var result = _passwordHasher.VerifyHashedPassword(user, user.HashedPin, dto.Pin);
+            if (result == PasswordVerificationResult.Success)
+            {
+                return Ok();
+            }
+
+            return Unauthorized();
+        }
+
+        [HttpGet("pin-timeout")]
+        [AllowAnonymous]
+        public IActionResult GetPinTimeout()
+        {
+            var timeout = _configuration.GetValue<int>("PinLock:TimeoutInMinutes");
+            return Ok(new { timeoutInMinutes = timeout });
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Account/PinDto.cs
+++ b/dekofar-hyperconnect-api/Controllers/Account/PinDto.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Dekofar.API.Controllers
+{
+    public class PinDto
+    {
+        [Required]
+        [RegularExpression("^\\d{4}$", ErrorMessage = "PIN must be exactly 4 digits.")]
+        public string Pin { get; set; } = string.Empty;
+    }
+}

--- a/dekofar-hyperconnect-api/appsettings.Development.json
+++ b/dekofar-hyperconnect-api/appsettings.Development.json
@@ -9,31 +9,26 @@
       "System": "Warning"
     }
   },
-
   "AllowedHosts": "*",
-
   "ConnectionStrings": {
     "DefaultConnection": "Host=dekofar-postgres.postgres.database.azure.com;Port=5432;Database=postgres;Username=dekofardbadmin;Password=@125896Aa;Ssl Mode=Require;Trust Server Certificate=true"
   },
-
   "Jwt": {
     "Key": "SuperSecretJwtKey_1234567890_LongEnough",
     "Issuer": "http://localhost:5036",
     "Audience": "http://localhost:5036",
     "ExpireMinutes": 60
   },
-
   "NetGsm": {
     "Username": "8503043225",
     "Password": "FDE2_73",
     "ReceiveSmsBaseUrl": "https://api.netgsm.com.tr/sms/receive/inbox"
   },
-
   "Shopify": {
     "BaseUrl": "https://nu10yf-mb.myshopify.com",
     "AccessToken": "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"
   },
-
-  "PinTimeoutInMinutes": 5
-
+  "PinLock": {
+    "TimeoutInMinutes": 5
+  }
 }

--- a/dekofar-hyperconnect-api/appsettings.json
+++ b/dekofar-hyperconnect-api/appsettings.json
@@ -9,31 +9,26 @@
       "System": "Warning"
     }
   },
-
   "AllowedHosts": "*",
-
   "ConnectionStrings": {
     "DefaultConnection": "Host=dekofar-postgres.postgres.database.azure.com;Port=5432;Database=postgres;Username=dekofardbadmin;Password=@125896Aa;Ssl Mode=Require;Trust Server Certificate=true"
   },
-
   "Jwt": {
     "Key": "SuperSecretJwtKey_1234567890_LongEnough",
     "Issuer": "http://localhost:5036",
     "Audience": "http://localhost:5036",
     "ExpireMinutes": 60
   },
-
   "NetGsm": {
     "Username": "8503043225",
     "Password": "FDE2_73",
     "ReceiveSmsBaseUrl": "https://api.netgsm.com.tr/sms/receive/inbox"
   },
-
   "Shopify": {
     "BaseUrl": "https://nu10yf-mb.myshopify.com",
     "AccessToken": "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"
   },
-
-  "PinTimeoutInMinutes": 5
-
+  "PinLock": {
+    "TimeoutInMinutes": 5
+  }
 }


### PR DESCRIPTION
## Summary
- add AccountController with endpoints to set and verify hashed 4-digit PINs and expose inactivity timeout
- define PinDto with validation for 4-digit PINs
- configure PinLock timeout in appsettings

## Testing
- `dotnet test` *(fails: AutoMapper.dll not found in Dekofar.HyperConnect.Tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e6ba803bc83268ac0f95acccb7904