### PR TITLE
feat: add notifications, badges and activity logging

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IActivityLogger.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IActivityLogger.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.Common.Interfaces
+{
+    public interface IActivityLogger
+    {
+        Task LogAsync(Guid userId, string actionType, object? data, string? ipAddress);
+    }
+}

--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -19,6 +19,9 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<Discount> Discounts { get; }
         DbSet<Note> Notes { get; }
         DbSet<AuditLog> AuditLogs { get; }
+        DbSet<ActivityLog> ActivityLogs { get; }
+        DbSet<UserNotification> UserNotifications { get; }
+        DbSet<UserBadge> UserBadges { get; }
         DbSet<ApplicationUser> Users { get; }
         DbSet<IdentityUserRole<Guid>> UserRoles { get; }
         DbSet<IdentityRole<Guid>> Roles { get; }

--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IBadgeService.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IBadgeService.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.Common.Interfaces
+{
+    public interface IBadgeService
+    {
+        Task EvaluateAsync(Guid userId);
+    }
+}

--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IUserNotificationService.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IUserNotificationService.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+
+namespace Dekofar.HyperConnect.Application.Common.Interfaces
+{
+    public interface IUserNotificationService
+    {
+        Task<UserNotification> CreateAsync(Guid userId, string title, string message, string type);
+        Task<List<UserNotification>> GetLatestAsync(Guid userId, int take = 20);
+        Task MarkAsReadAsync(Guid userId, Guid notificationId);
+        Task DeleteAsync(Guid userId, Guid notificationId);
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/ActivityLog.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ActivityLog.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class ActivityLog
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string ActionType { get; set; } = string.Empty;
+        public string? ActionData { get; set; }
+        public string? IpAddress { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/UserBadge.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/UserBadge.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class UserBadge
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string Badge { get; set; } = string.Empty;
+        public DateTime AwardedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/UserNotification.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/UserNotification.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class UserNotification
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Message { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public bool IsRead { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -31,6 +31,9 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<Discount> Discounts => Set<Discount>();
         public DbSet<Note> Notes => Set<Note>();
         public DbSet<AuditLog> AuditLogs => Set<AuditLog>();
+        public DbSet<ActivityLog> ActivityLogs => Set<ActivityLog>();
+        public DbSet<UserNotification> UserNotifications => Set<UserNotification>();
+        public DbSet<UserBadge> UserBadges => Set<UserBadge>();
         public DbSet<Permission> Permissions => Set<Permission>();
         public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
         public DbSet<UserMessage> UserMessages => Set<UserMessage>();
@@ -207,6 +210,31 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                       .WithMany()
                       .HasForeignKey(e => e.UserId)
                       .OnDelete(DeleteBehavior.Restrict);
+            });
+
+            builder.Entity<UserNotification>(entity =>
+            {
+                entity.ToTable("UserNotifications");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
+                entity.Property(e => e.Type).HasMaxLength(50);
+                entity.Property(e => e.CreatedAt).IsRequired();
+            });
+
+            builder.Entity<UserBadge>(entity =>
+            {
+                entity.ToTable("UserBadges");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Badge).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.AwardedAt).IsRequired();
+            });
+
+            builder.Entity<ActivityLog>(entity =>
+            {
+                entity.ToTable("ActivityLogs");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.ActionType).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.CreatedAt).IsRequired();
             });
         }
     }

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -90,6 +90,9 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             services.AddHttpContextAccessor(); // gerekli
             services.AddScoped<ICurrentUserService, CurrentUserService>();
             services.AddScoped<IFileStorageService, LocalFileStorageService>();
+            services.AddScoped<IActivityLogger, ActivityLogger>();
+            services.AddScoped<IUserNotificationService, UserNotificationService>();
+            services.AddScoped<IBadgeService, BadgeService>();
 
             services.AddScoped<SupportTicketJobService>();
 

--- a/Dekofar.HyperConnect.Infrastructure/Services/ActivityLogger.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/ActivityLogger.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    public class ActivityLogger : IActivityLogger
+    {
+        private readonly IApplicationDbContext _context;
+
+        public ActivityLogger(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task LogAsync(Guid userId, string actionType, object? data, string? ipAddress)
+        {
+            var log = new ActivityLog
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                ActionType = actionType,
+                ActionData = data != null ? JsonSerializer.Serialize(data) : null,
+                IpAddress = ipAddress,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _context.ActivityLogs.AddAsync(log);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Services/BadgeService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/BadgeService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    public class BadgeService : IBadgeService
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly IUserNotificationService _notificationService;
+
+        public BadgeService(IApplicationDbContext context, IUserNotificationService notificationService)
+        {
+            _context = context;
+            _notificationService = notificationService;
+        }
+
+        public async Task EvaluateAsync(Guid userId)
+        {
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null) return;
+
+            if (user.MembershipDate <= DateTime.UtcNow.AddMonths(-6))
+            {
+                bool has = await _context.UserBadges.AnyAsync(b => b.UserId == userId && b.Badge == "Joined 6+ months ago");
+                if (!has)
+                {
+                    var badge = new UserBadge
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = userId,
+                        Badge = "Joined 6+ months ago",
+                        AwardedAt = DateTime.UtcNow
+                    };
+                    await _context.UserBadges.AddAsync(badge);
+                    await _context.SaveChangesAsync();
+                    await _notificationService.CreateAsync(userId, "Badge Earned", "Joined 6+ months ago", "badge");
+                }
+            }
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Services/UserNotificationService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/UserNotificationService.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    public class UserNotificationService : IUserNotificationService
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly INotificationService _notificationService;
+
+        public UserNotificationService(IApplicationDbContext context, INotificationService notificationService)
+        {
+            _context = context;
+            _notificationService = notificationService;
+        }
+
+        public async Task<UserNotification> CreateAsync(Guid userId, string title, string message, string type)
+        {
+            var notification = new UserNotification
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Title = title,
+                Message = message,
+                Type = type,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            await _context.UserNotifications.AddAsync(notification);
+            await _context.SaveChangesAsync();
+
+            await _notificationService.SendToUserAsync(userId, "ReceiveNotification", new { notification.Id, notification.Title, notification.Message, notification.Type, notification.CreatedAt });
+
+            return notification;
+        }
+
+        public async Task<List<UserNotification>> GetLatestAsync(Guid userId, int take = 20)
+        {
+            return await _context.UserNotifications
+                .Where(n => n.UserId == userId)
+                .OrderByDescending(n => n.CreatedAt)
+                .Take(take)
+                .ToListAsync();
+        }
+
+        public async Task MarkAsReadAsync(Guid userId, Guid notificationId)
+        {
+            var notif = await _context.UserNotifications.FirstOrDefaultAsync(n => n.Id == notificationId && n.UserId == userId);
+            if (notif != null)
+            {
+                notif.IsRead = true;
+                await _context.SaveChangesAsync();
+            }
+        }
+
+        public async Task DeleteAsync(Guid userId, Guid notificationId)
+        {
+            var notif = await _context.UserNotifications.FirstOrDefaultAsync(n => n.Id == notificationId && n.UserId == userId);
+            if (notif != null)
+            {
+                _context.UserNotifications.Remove(notif);
+                await _context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Admin/UserActivityController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Admin/UserActivityController.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.API.Controllers.Admin
+{
+    [ApiController]
+    [Route("api/admin")]
+    [Authorize(Roles = "Admin")]
+    public class UserActivityController : ControllerBase
+    {
+        private readonly IApplicationDbContext _context;
+
+        public UserActivityController(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("user-activity-summary")]
+        public async Task<IActionResult> GetUserActivitySummary()
+        {
+            var loginStats = await _context.ActivityLogs
+                .Where(a => a.ActionType == "Login")
+                .GroupBy(a => a.UserId)
+                .Select(g => new { UserId = g.Key, LoginCount = g.Count(), LastActivity = g.Max(a => a.CreatedAt) })
+                .ToListAsync();
+
+            var users = await _context.Users
+                .Select(u => new { u.Id, u.FullName })
+                .ToListAsync();
+
+            var result = users.Select(u =>
+            {
+                var stat = loginStats.FirstOrDefault(s => s.UserId == u.Id);
+                return new
+                {
+                    u.Id,
+                    u.FullName,
+                    LoginCount = stat?.LoginCount ?? 0,
+                    LastActivity = stat?.LastActivity
+                };
+            })
+            .OrderByDescending(r => r.LoginCount)
+            .ToList();
+
+            return Ok(result);
+        }
+
+        [HttpGet("activity-logs")]
+        public async Task<IActionResult> GetLogs([FromQuery] Guid? userId, [FromQuery] string? actionType, [FromQuery] DateTime? from, [FromQuery] DateTime? to)
+        {
+            var query = _context.ActivityLogs.AsQueryable();
+            if (userId.HasValue)
+                query = query.Where(l => l.UserId == userId.Value);
+            if (!string.IsNullOrEmpty(actionType))
+                query = query.Where(l => l.ActionType == actionType);
+            if (from.HasValue)
+                query = query.Where(l => l.CreatedAt >= from.Value);
+            if (to.HasValue)
+                query = query.Where(l => l.CreatedAt <= to.Value);
+
+            var logs = await query.OrderByDescending(l => l.CreatedAt).Take(200).ToListAsync();
+            return Ok(logs);
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Notifications/UserNotificationsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Notifications/UserNotificationsController.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Threading.Tasks;
+using Dekofar.API.Authorization;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dekofar.API.Controllers
+{
+    [ApiController]
+    [Authorize]
+    [Route("api/notifications")]
+    public class UserNotificationsController : ControllerBase
+    {
+        private readonly IUserNotificationService _service;
+
+        public UserNotificationsController(IUserNotificationService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetMyNotifications()
+        {
+            var userId = User.GetUserId();
+            if (userId == null) return Unauthorized();
+            var list = await _service.GetLatestAsync(userId.Value);
+            return Ok(list);
+        }
+
+        [HttpPost("{id:guid}/read")]
+        public async Task<IActionResult> MarkAsRead(Guid id)
+        {
+            var userId = User.GetUserId();
+            if (userId == null) return Unauthorized();
+            await _service.MarkAsReadAsync(userId.Value, id);
+            return Ok();
+        }
+
+        [HttpDelete("{id:guid}")]
+        public async Task<IActionResult> Delete(Guid id)
+        {
+            var userId = User.GetUserId();
+            if (userId == null) return Unauthorized();
+            await _service.DeleteAsync(userId.Value, id);
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add user notification storage and real-time service
- introduce user badges and activity logging services
- expose endpoints for notifications and admin activity summary

## Testing
- `dotnet build`
- `dotnet test` *(fails: AutoMapper.dll missing)*

------
https://chatgpt.com/codex/tasks/task_e_688e6da042b083268759f6a5c0c99258