### PR TITLE
feat: add pin cover image support

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -29,6 +29,7 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<RolePermission> RolePermissions { get; }
         DbSet<UserMessage> UserMessages { get; }
         DbSet<SupportTicketReply> SupportTicketReplies { get; }
+        DbSet<PinCoverImage> PinCoverImages { get; }
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/PinCoverImage.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/PinCoverImage.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class PinCoverImage
+    {
+        public int Id { get; set; }
+        public string Url { get; set; } = default!;
+        public bool Active { get; set; }
+        public TimeSpan? DisplayStartTime { get; set; }
+        public TimeSpan? DisplayEndTime { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802220021_AddPinCoverImage.Designer.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802220021_AddPinCoverImage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Dekofar.HyperConnect.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250802220021_AddPinCoverImage")]
+    partial class AddPinCoverImage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Dekofar.HyperConnect.Infrastructure/Migrations/20250802220021_AddPinCoverImage.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Migrations/20250802220021_AddPinCoverImage.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Dekofar.HyperConnect.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPinCoverImage : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PinCoverImages",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Url = table.Column<string>(type: "text", nullable: false),
+                    Active = table.Column<bool>(type: "boolean", nullable: false),
+                    DisplayStartTime = table.Column<TimeSpan>(type: "interval", nullable: true),
+                    DisplayEndTime = table.Column<TimeSpan>(type: "interval", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PinCoverImages", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PinCoverImages");
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -38,6 +38,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
         public DbSet<UserMessage> UserMessages => Set<UserMessage>();
         public DbSet<SupportTicketReply> SupportTicketReplies => Set<SupportTicketReply>();
+        public DbSet<PinCoverImage> PinCoverImages => Set<PinCoverImage>();
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => await base.SaveChangesAsync(cancellationToken);
@@ -108,6 +109,13 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 entity.Property(e => e.IsActive).IsRequired();
                 entity.Property(e => e.CreatedByUserId).IsRequired();
                 entity.Property(e => e.CreatedAt).IsRequired();
+            });
+
+            builder.Entity<PinCoverImage>(entity =>
+            {
+                entity.ToTable("PinCoverImages");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.Url).IsRequired();
             });
 
             builder.Entity<OrderCommission>(entity =>

--- a/dekofar-hyperconnect-api/Controllers/System/PinCoversController.cs
+++ b/dekofar-hyperconnect-api/Controllers/System/PinCoversController.cs
@@ -1,0 +1,71 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Dekofar.API.Controllers
+{
+    [ApiController]
+    [Route("api/pin-covers")]
+    public class PinCoversController : ControllerBase
+    {
+        private readonly IApplicationDbContext _context;
+
+        public PinCoversController(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [AllowAnonymous]
+        [HttpGet("active")]
+        public async Task<IActionResult> GetActive()
+        {
+            var now = DateTime.UtcNow.TimeOfDay;
+            var images = await _context.PinCoverImages
+                .Where(p => p.Active &&
+                            (!p.DisplayStartTime.HasValue || !p.DisplayEndTime.HasValue ||
+                             (p.DisplayStartTime <= p.DisplayEndTime
+                                ? now >= p.DisplayStartTime && now <= p.DisplayEndTime
+                                : now >= p.DisplayStartTime || now <= p.DisplayEndTime)))
+                .ToListAsync();
+            return Ok(images);
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] PinCoverImage image)
+        {
+            _context.PinCoverImages.Add(image);
+            await _context.SaveChangesAsync();
+            return Ok(image.Id);
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var entity = await _context.PinCoverImages.FindAsync(id);
+            if (entity == null)
+                return NotFound();
+            _context.PinCoverImages.Remove(entity);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPut("{id}/activate")]
+        public async Task<IActionResult> Activate(int id, [FromBody] bool active)
+        {
+            var entity = await _context.PinCoverImages.FindAsync(id);
+            if (entity == null)
+                return NotFound();
+            entity.Active = active;
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `PinCoverImage` entity and DbContext mapping
- expose pin cover API endpoints for activation and retrieval
- include migration for pin cover images

## Testing
- `dotnet build`
- `dotnet test` *(fails: AutoMapper.dll missing)*

------
https://chatgpt.com/codex/tasks/task_e_688e89b0bd4083269ec97767ad127d83