### PR TITLE
feat: store user UI preferences

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -22,6 +22,7 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<ActivityLog> ActivityLogs { get; }
         DbSet<UserNotification> UserNotifications { get; }
         DbSet<UserBadge> UserBadges { get; }
+        DbSet<UserUIPreference> UserUIPreferences { get; }
         DbSet<ApplicationUser> Users { get; }
         DbSet<IdentityUserRole<Guid>> UserRoles { get; }
         DbSet<IdentityRole<Guid>> Roles { get; }

--- a/Dekofar.HyperConnect.Application/UIPreferences/Commands/UpsertUserUiPreferenceCommand.cs
+++ b/Dekofar.HyperConnect.Application/UIPreferences/Commands/UpsertUserUiPreferenceCommand.cs
@@ -1,0 +1,10 @@
+using MediatR;
+
+namespace Dekofar.HyperConnect.Application.UIPreferences.Commands
+{
+    public class UpsertUserUiPreferenceCommand : IRequest<Unit>
+    {
+        public string ModuleKey { get; set; } = default!;
+        public string PreferenceJson { get; set; } = default!;
+    }
+}

--- a/Dekofar.HyperConnect.Application/UIPreferences/DTOs/UserUiPreferenceDto.cs
+++ b/Dekofar.HyperConnect.Application/UIPreferences/DTOs/UserUiPreferenceDto.cs
@@ -1,0 +1,8 @@
+namespace Dekofar.HyperConnect.Application.UIPreferences.DTOs
+{
+    public class UserUiPreferenceDto
+    {
+        public string ModuleKey { get; set; } = default!;
+        public string PreferenceJson { get; set; } = default!;
+    }
+}

--- a/Dekofar.HyperConnect.Application/UIPreferences/Handlers/GetUserUiPreferenceHandler.cs
+++ b/Dekofar.HyperConnect.Application/UIPreferences/Handlers/GetUserUiPreferenceHandler.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.UIPreferences.DTOs;
+using Dekofar.HyperConnect.Application.UIPreferences.Queries;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.UIPreferences.Handlers
+{
+    public class GetUserUiPreferenceHandler : IRequestHandler<GetUserUiPreferenceQuery, UserUiPreferenceDto?>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public GetUserUiPreferenceHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<UserUiPreferenceDto?> Handle(GetUserUiPreferenceQuery request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var pref = await _context.UserUIPreferences
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.UserId == _currentUser.UserId && p.ModuleKey == request.ModuleKey, cancellationToken);
+
+            if (pref == null) return null;
+
+            return new UserUiPreferenceDto
+            {
+                ModuleKey = pref.ModuleKey,
+                PreferenceJson = pref.PreferenceJson
+            };
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UIPreferences/Handlers/UpsertUserUiPreferenceHandler.cs
+++ b/Dekofar.HyperConnect.Application/UIPreferences/Handlers/UpsertUserUiPreferenceHandler.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.UIPreferences.Commands;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Dekofar.HyperConnect.Application.UIPreferences.Handlers
+{
+    public class UpsertUserUiPreferenceHandler : IRequestHandler<UpsertUserUiPreferenceCommand, Unit>
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly ICurrentUserService _currentUser;
+
+        public UpsertUserUiPreferenceHandler(IApplicationDbContext context, ICurrentUserService currentUser)
+        {
+            _context = context;
+            _currentUser = currentUser;
+        }
+
+        public async Task<Unit> Handle(UpsertUserUiPreferenceCommand request, CancellationToken cancellationToken)
+        {
+            if (_currentUser.UserId == null)
+                throw new UnauthorizedAccessException();
+
+            var pref = await _context.UserUIPreferences
+                .FirstOrDefaultAsync(p => p.UserId == _currentUser.UserId && p.ModuleKey == request.ModuleKey, cancellationToken);
+
+            if (pref == null)
+            {
+                pref = new UserUIPreference
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = _currentUser.UserId.Value,
+                    ModuleKey = request.ModuleKey,
+                    PreferenceJson = request.PreferenceJson,
+                    UpdatedAt = DateTime.UtcNow
+                };
+                await _context.UserUIPreferences.AddAsync(pref, cancellationToken);
+            }
+            else
+            {
+                pref.PreferenceJson = request.PreferenceJson;
+                pref.UpdatedAt = DateTime.UtcNow;
+            }
+
+            await _context.SaveChangesAsync(cancellationToken);
+            return Unit.Value;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/UIPreferences/Queries/GetUserUiPreferenceQuery.cs
+++ b/Dekofar.HyperConnect.Application/UIPreferences/Queries/GetUserUiPreferenceQuery.cs
@@ -1,0 +1,7 @@
+using Dekofar.HyperConnect.Application.UIPreferences.DTOs;
+using MediatR;
+
+namespace Dekofar.HyperConnect.Application.UIPreferences.Queries
+{
+    public record GetUserUiPreferenceQuery(string ModuleKey) : IRequest<UserUiPreferenceDto?>;
+}

--- a/Dekofar.HyperConnect.Domain/Entities/UserUIPreference.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/UserUIPreference.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    public class UserUIPreference
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public string ModuleKey { get; set; } = default!;
+        public string PreferenceJson { get; set; } = default!;
+        public DateTime UpdatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -34,6 +34,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<ActivityLog> ActivityLogs => Set<ActivityLog>();
         public DbSet<UserNotification> UserNotifications => Set<UserNotification>();
         public DbSet<UserBadge> UserBadges => Set<UserBadge>();
+        public DbSet<UserUIPreference> UserUIPreferences => Set<UserUIPreference>();
         public DbSet<Permission> Permissions => Set<Permission>();
         public DbSet<RolePermission> RolePermissions => Set<RolePermission>();
         public DbSet<UserMessage> UserMessages => Set<UserMessage>();
@@ -244,6 +245,15 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 entity.HasKey(e => e.Id);
                 entity.Property(e => e.Badge).IsRequired().HasMaxLength(100);
                 entity.Property(e => e.AwardedAt).IsRequired();
+            });
+
+            builder.Entity<UserUIPreference>(entity =>
+            {
+                entity.ToTable("UserUIPreferences");
+                entity.HasKey(e => e.Id);
+                entity.Property(e => e.ModuleKey).IsRequired().HasMaxLength(100);
+                entity.Property(e => e.PreferenceJson).IsRequired();
+                entity.Property(e => e.UpdatedAt).IsRequired();
             });
 
             builder.Entity<ActivityLog>(entity =>

--- a/dekofar-hyperconnect-api/Controllers/UiPreferences/UiPreferencesController.cs
+++ b/dekofar-hyperconnect-api/Controllers/UiPreferences/UiPreferencesController.cs
@@ -1,0 +1,38 @@
+using Dekofar.HyperConnect.Application.UIPreferences.Commands;
+using Dekofar.HyperConnect.Application.UIPreferences.Queries;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace Dekofar.API.Controllers
+{
+    [ApiController]
+    [Route("api/ui-preferences")]
+    [Authorize]
+    public class UiPreferencesController : ControllerBase
+    {
+        private readonly IMediator _mediator;
+
+        public UiPreferencesController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        [HttpGet("{moduleKey}")]
+        public async Task<IActionResult> Get(string moduleKey)
+        {
+            var result = await _mediator.Send(new GetUserUiPreferenceQuery(moduleKey));
+            if (result == null)
+                return NotFound();
+            return Ok(result);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Upsert([FromBody] UpsertUserUiPreferenceCommand command)
+        {
+            await _mediator.Send(command);
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserUIPreference` entity and DbContext mappings
- implement query/command handlers for saving and retrieving user-specific UI settings
- expose `api/ui-preferences` endpoints to manage per-user module preferences

## Testing
- `dotnet build`
- `dotnet test` *(fails: AutoMapper.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e8ea5781c83268ef9c33f1d375978