### PR TITLE
Add AllowedAdminIp management service and controller

### DIFF
--- a/Dekofar.HyperConnect.Application/AllowedAdminIps/DTOs/AllowedAdminIpDto.cs
+++ b/Dekofar.HyperConnect.Application/AllowedAdminIps/DTOs/AllowedAdminIpDto.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Dekofar.HyperConnect.Application.AllowedAdminIps.DTOs
+{
+    // Yönetici paneli için izin verilen IP adresi bilgisini taşıyan DTO
+    public class AllowedAdminIpDto
+    {
+        // Kaydın benzersiz kimliği
+        public int Id { get; set; }
+
+        // İzin verilen IP adresi
+        public string IpAddress { get; set; } = string.Empty;
+
+        // IP adresine ilişkin açıklama
+        public string? Description { get; set; }
+
+        // Kaydın oluşturulma zamanı
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Interfaces/IAllowedAdminIpService.cs
+++ b/Dekofar.HyperConnect.Application/Interfaces/IAllowedAdminIpService.cs
@@ -1,0 +1,25 @@
+using Dekofar.HyperConnect.Application.AllowedAdminIps.DTOs;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.Interfaces
+{
+    // İzin verilen yönetici IP adresleri için servis arayüzü
+    public interface IAllowedAdminIpService
+    {
+        // Tüm izinli IP kayıtlarını döner
+        Task<List<AllowedAdminIpDto>> GetAllAsync();
+
+        // Belirli bir IP kaydını döner
+        Task<AllowedAdminIpDto?> GetByIdAsync(int id);
+
+        // Yeni bir IP kaydı oluşturur
+        Task<AllowedAdminIpDto> CreateAsync(AllowedAdminIpDto dto);
+
+        // Var olan IP kaydını günceller
+        Task<AllowedAdminIpDto?> UpdateAsync(int id, AllowedAdminIpDto dto);
+
+        // Belirli IP kaydını siler
+        Task<bool> DeleteAsync(int id);
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/AllowedAdminIp.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/AllowedAdminIp.cs
@@ -2,11 +2,19 @@ using System;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {
+    // Yönetici paneline erişimine izin verilen IP adreslerini temsil eden varlık
     public class AllowedAdminIp
     {
+        // IP kaydının benzersiz kimliği
         public int Id { get; set; }
+
+        // İzin verilen IP adresi
         public string IpAddress { get; set; } = string.Empty;
+
+        // IP adresi hakkında açıklama
         public string? Description { get; set; }
+
+        // Kaydın oluşturulma tarihi
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
     }
 }

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -3,6 +3,7 @@ using Dekofar.HyperConnect.Application.Common.Interfaces;
 using Dekofar.HyperConnect.Application.Interfaces;
 using Dekofar.HyperConnect.Domain.Entities;
 using Dekofar.HyperConnect.Infrastructure.Persistence;
+using Dekofar.HyperConnect.Infrastructure.Persistence.Repositories;
 using Dekofar.HyperConnect.Infrastructure.Services;
 using Dekofar.HyperConnect.Infrastructure.Jobs;
 using Dekofar.HyperConnect.Integrations.NetGsm.Interfaces;
@@ -93,6 +94,10 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             services.AddScoped<IActivityLogger, ActivityLogger>();
             services.AddScoped<IUserNotificationService, UserNotificationService>();
             services.AddScoped<IBadgeService, BadgeService>();
+
+            // 🌐 Genel depo ve IP servis kayıtları
+            services.AddScoped(typeof(IRepository<>), typeof(GenericRepository<>));
+            services.AddScoped<IAllowedAdminIpService, AllowedAdminIpService>();
 
             services.AddScoped<SupportTicketJobService>();
 

--- a/Dekofar.HyperConnect.Infrastructure/Services/AllowedAdminIpService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/AllowedAdminIpService.cs
@@ -1,0 +1,87 @@
+using Dekofar.HyperConnect.Application.AllowedAdminIps.DTOs;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    // İzin verilen yönetici IP adresleri için servis implementasyonu
+    public class AllowedAdminIpService : IAllowedAdminIpService
+    {
+        // Veri erişimi için genel depo
+        private readonly IRepository<AllowedAdminIp> _repository;
+
+        // Servis için kurucu
+        public AllowedAdminIpService(IRepository<AllowedAdminIp> repository)
+        {
+            _repository = repository;
+        }
+
+        // Tüm izinli IP adreslerini döner
+        public async Task<List<AllowedAdminIpDto>> GetAllAsync()
+        {
+            return await _repository.GetAll()
+                .Select(x => new AllowedAdminIpDto
+                {
+                    Id = x.Id,
+                    IpAddress = x.IpAddress,
+                    Description = x.Description,
+                    CreatedAt = x.CreatedAt
+                })
+                .ToListAsync();
+        }
+
+        // Belirli bir IP kaydını getirir
+        public async Task<AllowedAdminIpDto?> GetByIdAsync(int id)
+        {
+            var entity = await _repository.GetByIdAsync(id);
+            if (entity == null) return null;
+            return new AllowedAdminIpDto
+            {
+                Id = entity.Id,
+                IpAddress = entity.IpAddress,
+                Description = entity.Description,
+                CreatedAt = entity.CreatedAt
+            };
+        }
+
+        // Yeni bir IP kaydı oluşturur
+        public async Task<AllowedAdminIpDto> CreateAsync(AllowedAdminIpDto dto)
+        {
+            var entity = new AllowedAdminIp
+            {
+                IpAddress = dto.IpAddress,
+                Description = dto.Description
+            };
+            var created = await _repository.AddAsync(entity);
+            dto.Id = created.Id;
+            dto.CreatedAt = created.CreatedAt;
+            return dto;
+        }
+
+        // IP kaydını günceller
+        public async Task<AllowedAdminIpDto?> UpdateAsync(int id, AllowedAdminIpDto dto)
+        {
+            var entity = await _repository.GetByIdAsync(id);
+            if (entity == null) return null;
+            entity.IpAddress = dto.IpAddress;
+            entity.Description = dto.Description;
+            var updated = await _repository.UpdateAsync(entity);
+            return new AllowedAdminIpDto
+            {
+                Id = updated.Id,
+                IpAddress = updated.IpAddress,
+                Description = updated.Description,
+                CreatedAt = updated.CreatedAt
+            };
+        }
+
+        // IP kaydını siler
+        public async Task<bool> DeleteAsync(int id)
+        {
+            return await _repository.DeleteAsync(id);
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/Admin/AllowedAdminIpsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/Admin/AllowedAdminIpsController.cs
@@ -1,0 +1,67 @@
+using Dekofar.HyperConnect.Application.AllowedAdminIps.DTOs;
+using Dekofar.HyperConnect.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+
+namespace Dekofar.API.Controllers
+{
+    [ApiController]
+    [Route("api/admin/allowed-ips")]
+    [Authorize(Roles = "Admin")]
+    // Yönetici paneline erişimine izin verilen IP adreslerini yöneten controller
+    public class AllowedAdminIpsController : ControllerBase
+    {
+        // IP servisinin arayüzü
+        private readonly IAllowedAdminIpService _service;
+
+        // Servisi alan kurucu
+        public AllowedAdminIpsController(IAllowedAdminIpService service)
+        {
+            _service = service;
+        }
+
+        // Tüm izinli IP adreslerini listeler
+        [HttpGet]
+        public async Task<ActionResult<List<AllowedAdminIpDto>>> GetAll()
+        {
+            var items = await _service.GetAllAsync();
+            return Ok(items);
+        }
+
+        // Belirli bir izinli IP kaydını getirir
+        [HttpGet("{id}")]
+        public async Task<ActionResult<AllowedAdminIpDto>> GetById(int id)
+        {
+            var item = await _service.GetByIdAsync(id);
+            if (item == null) return NotFound();
+            return Ok(item);
+        }
+
+        // Yeni bir izinli IP kaydı oluşturur
+        [HttpPost]
+        public async Task<ActionResult<AllowedAdminIpDto>> Create([FromBody] AllowedAdminIpDto dto)
+        {
+            var created = await _service.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        // Var olan izinli IP kaydını günceller
+        [HttpPut("{id}")]
+        public async Task<ActionResult<AllowedAdminIpDto>> Update(int id, [FromBody] AllowedAdminIpDto dto)
+        {
+            var updated = await _service.UpdateAsync(id, dto);
+            if (updated == null) return NotFound();
+            return Ok(updated);
+        }
+
+        // Bir izinli IP kaydını siler
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var result = await _service.DeleteAsync(id);
+            if (!result) return NotFound();
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce DTO and interface for managing allowed admin IP addresses
- implement service with repository usage and register in DI
- expose CRUD endpoints for allowed admin IPs

## Testing
- `dotnet build`
- `dotnet test` *(fails: package 'AutoMapper' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa6036c848326a63a3aba72434f2d