### PR TITLE
feat: add support ticket listing endpoint

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Models/PagedResult.cs
+++ b/Dekofar.HyperConnect.Application/Common/Models/PagedResult.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+
+namespace Dekofar.HyperConnect.Application.Common.Models
+{
+    /// <summary>
+    /// Genel bir sayfalama sonucu modeli.
+    /// İstenen veri listesi ile toplam kayıt sayısı gibi bilgileri tutar.
+    /// </summary>
+    /// <typeparam name="T">Listelemede dönecek veri tipi</typeparam>
+    public class PagedResult<T>
+    {
+        /// <summary>
+        /// Sayfadaki elemanların listesi
+        /// </summary>
+        public List<T> Items { get; set; } = new();
+
+        /// <summary>
+        /// Toplam kayıt sayısı
+        /// </summary>
+        public int TotalCount { get; set; }
+
+        /// <summary>
+        /// Sayfa başına gösterilecek kayıt sayısı
+        /// </summary>
+        public int PageSize { get; set; }
+
+        /// <summary>
+        /// Mevcut sayfa numarası
+        /// </summary>
+        public int CurrentPage { get; set; }
+
+        /// <summary>
+        /// Toplam sayfa sayısı
+        /// </summary>
+        public int TotalPages { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetAllSupportTicketsQuery.cs
+++ b/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetAllSupportTicketsQuery.cs
@@ -1,0 +1,50 @@
+using Dekofar.HyperConnect.Application.Common.Models;
+using Dekofar.HyperConnect.Application.SupportTickets.DTOs;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using System;
+
+namespace Dekofar.HyperConnect.Application.SupportTickets.Queries
+{
+    /// <summary>
+    /// Tüm destek taleplerini listelemek için kullanılan sorgu nesnesi.
+    /// Rol ve filtre bilgilerinin tamamı bu sınıf üzerinden handler'a aktarılır.
+    /// </summary>
+    public class GetAllSupportTicketsQuery : IRequest<PagedResult<SupportTicketDto>>
+    {
+        /// <summary>
+        /// Listeyi çeken kullanıcının benzersiz kimliği
+        /// </summary>
+        public Guid UserId { get; set; }
+
+        /// <summary>
+        /// Kullanıcının yönetici olup olmadığı bilgisi
+        /// </summary>
+        public bool IsAdmin { get; set; }
+
+        /// <summary>
+        /// İstenen sayfa numarası (1 tabanlı)
+        /// </summary>
+        public int PageNumber { get; set; } = 1;
+
+        /// <summary>
+        /// Sayfa başına gösterilecek kayıt sayısı
+        /// </summary>
+        public int PageSize { get; set; } = 10;
+
+        /// <summary>
+        /// Filtrelenecek kategori kimliği (isteğe bağlı)
+        /// </summary>
+        public Guid? CategoryId { get; set; }
+
+        /// <summary>
+        /// Filtrelenecek durum bilgisi (isteğe bağlı)
+        /// </summary>
+        public SupportTicketStatus? Status { get; set; }
+
+        /// <summary>
+        /// Başlık veya açıklama üzerinde arama yapılacak metin
+        /// </summary>
+        public string? Search { get; set; }
+    }
+}

--- a/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetAllSupportTicketsQueryHandler.cs
+++ b/Dekofar.HyperConnect.Application/SupportTickets/Queries/GetAllSupportTicketsQueryHandler.cs
@@ -1,0 +1,101 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Application.Common.Models;
+using Dekofar.HyperConnect.Application.SupportTickets.DTOs;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.SupportTickets.Queries
+{
+    /// <summary>
+    /// Destek taleplerini listeleme sorgusunu ele alan handler sınıfı.
+    /// Kullanıcının rolüne göre gerekli filtrelemeleri yapar ve sayfalı sonuç döner.
+    /// </summary>
+    public class GetAllSupportTicketsQueryHandler : IRequestHandler<GetAllSupportTicketsQuery, PagedResult<SupportTicketDto>>
+    {
+        private readonly IApplicationDbContext _context;
+
+        public GetAllSupportTicketsQueryHandler(IApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        /// <summary>
+        /// Sorguyu işler ve kullanıcı yetkilerine göre filtrelenmiş destek taleplerini döner.
+        /// </summary>
+        public async Task<PagedResult<SupportTicketDto>> Handle(GetAllSupportTicketsQuery request, CancellationToken cancellationToken)
+        {
+            if (request.UserId == Guid.Empty)
+                throw new UnauthorizedAccessException();
+
+            // Temel sorgu tanımı
+            var query = _context.SupportTickets.AsQueryable();
+
+            // Yönetici değilse sadece kendi oluşturduğu veya kendisine atanan kayıtları görür
+            if (!request.IsAdmin)
+            {
+                query = query.Where(t => t.CreatedByUserId == request.UserId || t.AssignedUserId == request.UserId);
+            }
+
+            // Kategori filtresi uygulanır
+            if (request.CategoryId.HasValue)
+            {
+                query = query.Where(t => t.CategoryId == request.CategoryId);
+            }
+
+            // Durum filtresi uygulanır
+            if (request.Status.HasValue)
+            {
+                query = query.Where(t => t.Status == request.Status);
+            }
+
+            // Başlık veya açıklamada arama yapılır
+            if (!string.IsNullOrWhiteSpace(request.Search))
+            {
+                var search = request.Search.ToLower();
+                query = query.Where(t => t.Title.ToLower().Contains(search) || t.Description.ToLower().Contains(search));
+            }
+
+            // Toplam kayıt sayısı hesaplanır
+            var totalCount = await query.CountAsync(cancellationToken);
+
+            // Sayfalama uygulanarak veriler çekilir
+            var tickets = await query
+                .OrderByDescending(t => t.CreatedAt)
+                .Skip((request.PageNumber - 1) * request.PageSize)
+                .Take(request.PageSize)
+                .Select(t => new SupportTicketDto
+                {
+                    Id = t.Id,
+                    Title = t.Title,
+                    Description = t.Description,
+                    CreatedByUserId = t.CreatedByUserId,
+                    AssignedUserId = t.AssignedUserId,
+                    CategoryId = t.CategoryId,
+                    OrderId = t.OrderId,
+                    Status = t.Status,
+                    Priority = t.Priority,
+                    DueDate = t.DueDate,
+                    FilePath = t.FilePath,
+                    CreatedAt = t.CreatedAt,
+                    LastUpdatedAt = t.LastUpdatedAt,
+                    UnreadReplyCount = t.UnreadReplyCount
+                })
+                .ToListAsync(cancellationToken);
+
+            // Sonuç modeli hazırlanır
+            return new PagedResult<SupportTicketDto>
+            {
+                Items = tickets,
+                TotalCount = totalCount,
+                PageSize = request.PageSize,
+                CurrentPage = request.PageNumber,
+                TotalPages = (int)Math.Ceiling(totalCount / (double)request.PageSize)
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add generic paged result model
- implement support ticket list query with role based filtering
- expose GET /api/support-tickets with pagination and search

## Testing
- `dotnet build`
- `dotnet test` *(fails: AutoMapper.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fa9de2b588326bdf7842a18d04870