### PR TITLE
feat: add user profile management and work session tracking

### DIFF
--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IApplicationDbContext.cs
@@ -34,6 +34,10 @@ namespace Dekofar.HyperConnect.Application.Common.Interfaces
         DbSet<ResponseTemplate> ResponseTemplates { get; }
         DbSet<ModerationRule> ModerationRules { get; }
         DbSet<ModerationLog> ModerationLogs { get; }
+        /// <summary>
+        /// Kullanıcı çalışma oturumları tablosu
+        /// </summary>
+        DbSet<WorkSession> WorkSessions { get; }
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Dekofar.HyperConnect.Application/Common/Interfaces/IWorkSessionService.cs
+++ b/Dekofar.HyperConnect.Application/Common/Interfaces/IWorkSessionService.cs
@@ -1,0 +1,33 @@
+using Dekofar.HyperConnect.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Application.Common.Interfaces
+{
+    /// <summary>
+    /// Kullanıcı çalışma oturumlarını yöneten servis sözleşmesi.
+    /// </summary>
+    public interface IWorkSessionService
+    {
+        /// <summary>
+        /// Kullanıcı için yeni bir oturum başlatır.
+        /// </summary>
+        Task<WorkSession> StartSessionAsync(Guid userId, string? ip);
+
+        /// <summary>
+        /// Kullanıcının aktif oturumunu sonlandırır.
+        /// </summary>
+        Task<WorkSession?> EndSessionAsync(Guid userId);
+
+        /// <summary>
+        /// Belirli kullanıcının oturum listesini döner.
+        /// </summary>
+        Task<List<WorkSession>> GetUserSessionsAsync(Guid userId);
+
+        /// <summary>
+        /// Tüm oturumlar için rapor üretir (admin).
+        /// </summary>
+        Task<List<WorkSession>> GetReportAsync();
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/ChangePasswordCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/ChangePasswordCommand.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    /// <summary>
+    /// Kullanıcının mevcut şifresini değiştirir.
+    /// </summary>
+    public class ChangePasswordCommand : IRequest<IdentityResult>
+    {
+        public Guid UserId { get; set; }
+        public string CurrentPassword { get; set; } = string.Empty;
+        public string NewPassword { get; set; } = string.Empty;
+    }
+
+    public class ChangePasswordCommandHandler : IRequestHandler<ChangePasswordCommand, IdentityResult>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public ChangePasswordCommandHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<IdentityResult> Handle(ChangePasswordCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "Kullanıcı bulunamadı." });
+            return await _userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/DeleteUserCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/DeleteUserCommand.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    /// <summary>
+    /// Admin tarafından kullanıcı silme komutu.
+    /// </summary>
+    public class DeleteUserCommand : IRequest<IdentityResult>
+    {
+        public Guid UserId { get; set; }
+    }
+
+    public class DeleteUserCommandHandler : IRequestHandler<DeleteUserCommand, IdentityResult>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public DeleteUserCommandHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<IdentityResult> Handle(DeleteUserCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "Kullanıcı bulunamadı." });
+            return await _userManager.DeleteAsync(user);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/RemoveProfileImageCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/RemoveProfileImageCommand.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    /// <summary>
+    /// Kullanıcı profil resmini kaldırmak için kullanılan komut.
+    /// </summary>
+    public class RemoveProfileImageCommand : IRequest<IdentityResult>
+    {
+        public Guid UserId { get; set; }
+    }
+
+    public class RemoveProfileImageCommandHandler : IRequestHandler<RemoveProfileImageCommand, IdentityResult>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public RemoveProfileImageCommandHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<IdentityResult> Handle(RemoveProfileImageCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "Kullanıcı bulunamadı." });
+            user.AvatarUrl = null;
+            return await _userManager.UpdateAsync(user);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/ResetPasswordCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/ResetPasswordCommand.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    /// <summary>
+    /// Admin tarafından kullanıcı şifresini sıfırlamak için kullanılan komut.
+    /// </summary>
+    public class ResetPasswordCommand : IRequest<IdentityResult>
+    {
+        public Guid UserId { get; set; }
+        public string NewPassword { get; set; } = string.Empty;
+    }
+
+    public class ResetPasswordCommandHandler : IRequestHandler<ResetPasswordCommand, IdentityResult>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public ResetPasswordCommandHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<IdentityResult> Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "Kullanıcı bulunamadı." });
+
+            var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+            return await _userManager.ResetPasswordAsync(user, token, request.NewPassword);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Commands/UpdateUserCommand.cs
+++ b/Dekofar.HyperConnect.Application/Users/Commands/UpdateUserCommand.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+
+namespace Dekofar.HyperConnect.Application.Users.Commands
+{
+    /// <summary>
+    /// Kullanıcı profil bilgilerini güncellemek için kullanılan komut.
+    /// </summary>
+    public class UpdateUserCommand : IRequest<IdentityResult>
+    {
+        // Güncellenecek kullanıcının kimliği
+        public Guid Id { get; set; }
+        // Yeni tam ad
+        public string? FullName { get; set; }
+        // Yeni e-posta adresi
+        public string? Email { get; set; }
+    }
+
+    public class UpdateUserCommandHandler : IRequestHandler<UpdateUserCommand, IdentityResult>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public UpdateUserCommandHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<IdentityResult> Handle(UpdateUserCommand request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.Id.ToString());
+            if (user == null)
+                return IdentityResult.Failed(new IdentityError { Description = "Kullanıcı bulunamadı." });
+
+            if (!string.IsNullOrWhiteSpace(request.FullName))
+                user.FullName = request.FullName;
+            if (!string.IsNullOrWhiteSpace(request.Email))
+            {
+                user.Email = request.Email;
+                user.UserName = request.Email;
+            }
+            return await _userManager.UpdateAsync(user);
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Application/Users/Queries/GetUserProfileQuery.cs
+++ b/Dekofar.HyperConnect.Application/Users/Queries/GetUserProfileQuery.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Users.DTOs;
+using Dekofar.HyperConnect.Domain.Entities;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using System.Linq;
+
+namespace Dekofar.HyperConnect.Application.Users.Queries
+{
+    /// <summary>
+    /// Mevcut kullanıcı profilini dönen sorgu.
+    /// </summary>
+    public class GetUserProfileQuery : IRequest<UserDto?>
+    {
+        public Guid UserId { get; set; }
+    }
+
+    public class GetUserProfileQueryHandler : IRequestHandler<GetUserProfileQuery, UserDto?>
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public GetUserProfileQueryHandler(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<UserDto?> Handle(GetUserProfileQuery request, CancellationToken cancellationToken)
+        {
+            var user = await _userManager.FindByIdAsync(request.UserId.ToString());
+            if (user == null) return null;
+            var roles = await _userManager.GetRolesAsync(user);
+            return new UserDto
+            {
+                Id = user.Id,
+                Email = user.Email,
+                FullName = user.FullName,
+                Roles = roles.ToList()
+            };
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Domain/Entities/WorkSession.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/WorkSession.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Dekofar.HyperConnect.Domain.Entities
+{
+    /// <summary>
+    /// Kullanıcıların aktif çalışma sürelerini takip eden oturum kaydı.
+    /// </summary>
+    public class WorkSession
+    {
+        // Oturum benzersiz kimliği
+        public Guid Id { get; set; }
+
+        // Oturumu başlatan kullanıcının kimliği
+        public Guid UserId { get; set; }
+
+        // Kullanıcı navigasyon özelliği
+        public ApplicationUser User { get; set; } = default!;
+
+        // Oturum başlangıç zamanı
+        public DateTime StartTime { get; set; }
+
+        // Oturum bitiş zamanı (null ise devam ediyor)
+        public DateTime? EndTime { get; set; }
+
+        // Oturum başlangıcındaki IP adresi
+        public string? StartIp { get; set; }
+
+        // Oturum süresi (EndTime - StartTime)
+        public TimeSpan? Duration => EndTime.HasValue ? EndTime - StartTime : null;
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/ApplicationDbContext.cs
@@ -47,6 +47,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
         public DbSet<ResponseTemplate> ResponseTemplates => Set<ResponseTemplate>();
         public DbSet<ModerationRule> ModerationRules => Set<ModerationRule>();
         public DbSet<ModerationLog> ModerationLogs => Set<ModerationLog>();
+        public DbSet<WorkSession> WorkSessions => Set<WorkSession>();
 
         public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
             => await base.SaveChangesAsync(cancellationToken);

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -94,6 +94,7 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             services.AddScoped<IActivityLogger, ActivityLogger>();
             services.AddScoped<IUserNotificationService, UserNotificationService>();
             services.AddScoped<IBadgeService, BadgeService>();
+            services.AddScoped<IWorkSessionService, WorkSessionService>();
 
             // 🌐 Genel depo ve IP servis kayıtları
             services.AddScoped(typeof(IRepository<>), typeof(GenericRepository<>));

--- a/Dekofar.HyperConnect.Infrastructure/Services/WorkSessionService.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Services/WorkSessionService.cs
@@ -1,0 +1,102 @@
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Dekofar.HyperConnect.Infrastructure.Services
+{
+    /// <summary>
+    /// Kullanıcı çalışma oturumlarını yöneten servis.
+    /// </summary>
+    public class WorkSessionService : IWorkSessionService
+    {
+        private readonly IApplicationDbContext _context;
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public WorkSessionService(IApplicationDbContext context, UserManager<ApplicationUser> userManager)
+        {
+            _context = context;
+            _userManager = userManager;
+        }
+
+        /// <summary>
+        /// Kullanıcı için oturumu başlatır ve IsOnline alanını günceller.
+        /// </summary>
+        public async Task<WorkSession> StartSessionAsync(Guid userId, string? ip)
+        {
+            var user = await _userManager.FindByIdAsync(userId.ToString());
+            if (user == null) throw new Exception("Kullanıcı bulunamadı.");
+
+            var session = new WorkSession
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                StartTime = DateTime.UtcNow,
+                StartIp = ip
+            };
+
+            user.IsOnline = true;
+            user.LastSeen = DateTime.UtcNow;
+
+            _context.WorkSessions.Add(session);
+            await _userManager.UpdateAsync(user);
+            await _context.SaveChangesAsync();
+            return session;
+        }
+
+        /// <summary>
+        /// Aktif oturumu sonlandırır ve kullanıcıyı offline yapar.
+        /// </summary>
+        public async Task<WorkSession?> EndSessionAsync(Guid userId)
+        {
+            var session = await _context.WorkSessions
+                .Where(x => x.UserId == userId && x.EndTime == null)
+                .OrderByDescending(x => x.StartTime)
+                .FirstOrDefaultAsync();
+
+            var user = await _userManager.FindByIdAsync(userId.ToString());
+            if (user != null)
+            {
+                user.IsOnline = false;
+                user.LastSeen = DateTime.UtcNow;
+                await _userManager.UpdateAsync(user);
+            }
+
+            if (session == null)
+            {
+                await _context.SaveChangesAsync();
+                return null;
+            }
+
+            session.EndTime = DateTime.UtcNow;
+            await _context.SaveChangesAsync();
+            return session;
+        }
+
+        /// <summary>
+        /// Kullanıcının geçmiş oturumlarını listeler.
+        /// </summary>
+        public async Task<List<WorkSession>> GetUserSessionsAsync(Guid userId)
+        {
+            return await _context.WorkSessions
+                .Where(x => x.UserId == userId)
+                .OrderByDescending(x => x.StartTime)
+                .ToListAsync();
+        }
+
+        /// <summary>
+        /// Tüm oturumları içeren rapor döner (sadece admin).
+        /// </summary>
+        public async Task<List<WorkSession>> GetReportAsync()
+        {
+            return await _context.WorkSessions
+                .Include(x => x.User)
+                .OrderByDescending(x => x.StartTime)
+                .ToListAsync();
+        }
+    }
+}

--- a/dekofar-hyperconnect-api/Controllers/WorkSessions/WorkSessionsController.cs
+++ b/dekofar-hyperconnect-api/Controllers/WorkSessions/WorkSessionsController.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Dekofar.HyperConnect.Application.Common.Interfaces;
+using Dekofar.HyperConnect.Domain.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Dekofar.API.Controllers
+{
+    /// <summary>
+    /// Kullanıcı çalışma oturumlarını yöneten controller.
+    /// </summary>
+    [ApiController]
+    [Route("api/work-sessions")]
+    public class WorkSessionsController : ControllerBase
+    {
+        private readonly IWorkSessionService _workSessionService;
+
+        public WorkSessionsController(IWorkSessionService workSessionService)
+        {
+            _workSessionService = workSessionService;
+        }
+
+        // Bu endpoint kullanıcı oturumunu başlatmak için kullanılır.
+        // Erişim: Giriş yapmış tüm kullanıcılar.
+        // Girdi: Yok, çıktı: oluşturulan WorkSession
+        [HttpPost("start")]
+        [Authorize]
+        public async Task<ActionResult<WorkSession>> Start()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+            var session = await _workSessionService.StartSessionAsync(Guid.Parse(userId), HttpContext.Connection.RemoteIpAddress?.ToString());
+            return Ok(session);
+        }
+
+        // Bu endpoint aktif oturumu sonlandırır.
+        // Erişim: Giriş yapmış tüm kullanıcılar.
+        // Girdi: Yok, çıktı: sonlanan WorkSession
+        [HttpPost("end")]
+        [Authorize]
+        public async Task<ActionResult<WorkSession?>> End()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+            var session = await _workSessionService.EndSessionAsync(Guid.Parse(userId));
+            return Ok(session);
+        }
+
+        // Bu endpoint mevcut kullanıcının oturum geçmişini listeler.
+        // Erişim: Giriş yapmış tüm kullanıcılar.
+        // Girdi: Yok, çıktı: WorkSession listesi
+        [HttpGet("my")]
+        [Authorize]
+        public async Task<ActionResult> MySessions()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null) return Unauthorized();
+            var sessions = await _workSessionService.GetUserSessionsAsync(Guid.Parse(userId));
+            return Ok(sessions);
+        }
+
+        // Bu endpoint tüm oturumları rapor olarak döner.
+        // Erişim: Admin
+        // Girdi: Yok, çıktı: WorkSession listesi
+        [HttpGet("report")]
+        [Authorize(Roles = "Admin")]
+        public async Task<ActionResult> Report()
+        {
+            var sessions = await _workSessionService.GetReportAsync();
+            return Ok(sessions);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend users controller with profile, password, avatar and deletion endpoints
- introduce WorkSession entity and service for tracking user activity
- update auth flow to start sessions and expose session endpoints

## Testing
- `dotnet build`
- `dotnet test` *(fails: AutoMapper assembly not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fad5f2a408326984c69b26e6dfbcc