### PR TITLE
fix: prevent swagger schema recursion

### DIFF
--- a/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ApplicationUser.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Identity;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {
@@ -55,7 +56,11 @@ namespace Dekofar.HyperConnect.Domain.Entities
             set => LastSupportActivity = value;
         }
 
+        // Navigation collections cause self-referencing loops; ignore for Swagger
+        [JsonIgnore]
         public ICollection<Order> Orders { get; set; } = new List<Order>();
+
+        [JsonIgnore]
         public ICollection<Commission> Commissions { get; set; } = new List<Commission>();
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/ManualOrderItem.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ManualOrderItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {
@@ -12,6 +13,8 @@ namespace Dekofar.HyperConnect.Domain.Entities
         public decimal Price { get; set; }
         public decimal Total { get; set; }
 
+        // Avoid self-referential loop during Swagger schema generation
+        [JsonIgnore]
         public ManualOrder? ManualOrder { get; set; }
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/SupportCategory.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/SupportCategory.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 namespace Dekofar.HyperConnect.Domain.Entities
 {
     public class SupportCategory
@@ -10,6 +11,9 @@ namespace Dekofar.HyperConnect.Domain.Entities
         public DateTime CreatedAt { get; set; }
 
         public ICollection<SupportCategoryRole> Roles { get; set; } = new List<SupportCategoryRole>();
+
+        // Prevent recursive schema generation with SupportTicket.Category
+        [JsonIgnore]
         public ICollection<SupportTicket> Tickets { get; set; } = new List<SupportTicket>();
     }
 }

--- a/Dekofar.HyperConnect.Domain/Entities/SupportCategoryRole.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/SupportCategoryRole.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json.Serialization;
 
 namespace Dekofar.HyperConnect.Domain.Entities
 {
@@ -8,6 +9,8 @@ namespace Dekofar.HyperConnect.Domain.Entities
         public Guid SupportCategoryId { get; set; }
         public string RoleName { get; set; } = default!;
 
+        // Ignore back-reference to avoid recursive schemas in Swagger
+        [JsonIgnore]
         public SupportCategory? Category { get; set; }
     }
 }

--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.IdentityModel.Tokens.Jwt;
+using System.Reflection; // Needed for XML comments
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
@@ -118,7 +119,17 @@ builder.Services.AddSwaggerGen(c =>
     {
         { jwtSecurityScheme, Array.Empty<string>() }
     });
+
+    // Swashbuckle options to handle complex schemas and parameter naming
+    c.UseAllOfToExtendReferenceSchemas();
+    c.DescribeAllParametersInCamelCase();
+
+    // Include generated XML comments for better documentation
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    c.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
 });
+
 
 // 📋 Logging
 builder.Logging.ClearProviders();

--- a/dekofar-hyperconnect-api/dekofar-hyperconnect-api.csproj
+++ b/dekofar-hyperconnect-api/dekofar-hyperconnect-api.csproj
@@ -6,6 +6,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>dekofar_hyperconnect_api</RootNamespace>
     <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+    <!-- Generate XML documentation for Swagger -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- prevent Swagger loops by ignoring back-references on order and support entities
- configure Swashbuckle with better schema handling and XML comments
- generate XML docs in API project

## Testing
- `dotnet build`
- `dotnet test` *(fails: AutoMapper.dll not found)*
- `curl -s -o /tmp/swagger.json -w "%{http_code}" http://localhost:5036/swagger/v1/swagger.json`


------
https://chatgpt.com/codex/tasks/task_e_688fb3a2ad2c8326a3677adcaa4c0918