### PR TITLE
feat: add Shopify variant support to manual orders

### DIFF
--- a/Dekofar.HyperConnect.Application/ManualOrders/Commands/CreateManualOrderCommand.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/Commands/CreateManualOrderCommand.cs
@@ -39,6 +39,8 @@ namespace Dekofar.HyperConnect.Application.ManualOrders.Commands
         [Range(1, int.MaxValue)]
         public int Quantity { get; set; }
         public decimal Price { get; set; }
+        public string? VariantId { get; set; }
+        public string? VariantName { get; set; }
     }
 }
 

--- a/Dekofar.HyperConnect.Application/ManualOrders/DTOs/ManualOrderDto.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/DTOs/ManualOrderDto.cs
@@ -31,6 +31,8 @@ namespace Dekofar.HyperConnect.Application.ManualOrders.DTOs
         public Guid Id { get; set; }
         public string ProductId { get; set; } = default!;
         public string ProductName { get; set; } = default!;
+        public string? VariantId { get; set; }
+        public string? VariantName { get; set; }
         public int Quantity { get; set; }
         public decimal Price { get; set; }
         public decimal Total { get; set; }

--- a/Dekofar.HyperConnect.Application/ManualOrders/Handlers/CreateManualOrderHandler.cs
+++ b/Dekofar.HyperConnect.Application/ManualOrders/Handlers/CreateManualOrderHandler.cs
@@ -49,6 +49,8 @@ namespace Dekofar.HyperConnect.Application.ManualOrders.Handlers
                 {
                     ProductId = item.ProductId,
                     ProductName = item.ProductName,
+                    VariantId = item.VariantId,
+                    VariantName = item.VariantName,
                     Quantity = item.Quantity,
                     Price = item.Price,
                     Total = item.Price * item.Quantity

--- a/Dekofar.HyperConnect.Domain/Entities/ManualOrderItem.cs
+++ b/Dekofar.HyperConnect.Domain/Entities/ManualOrderItem.cs
@@ -9,6 +9,8 @@ namespace Dekofar.HyperConnect.Domain.Entities
         public Guid ManualOrderId { get; set; }
         public string ProductId { get; set; } = default!;
         public string ProductName { get; set; } = default!;
+        public string? VariantId { get; set; }
+        public string? VariantName { get; set; }
         public int Quantity { get; set; }
         public decimal Price { get; set; }
         public decimal Total { get; set; }

--- a/dekofar-hyperconnect-api/Controllers/ManualOrders/ManualOrdersController.cs
+++ b/dekofar-hyperconnect-api/Controllers/ManualOrders/ManualOrdersController.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 
 namespace Dekofar.API.Controllers
 {
@@ -31,7 +32,10 @@ namespace Dekofar.API.Controllers
         public async Task<IActionResult> GetAll()
         {
             // Veritabanından tüm manuel siparişleri çeker
-            var orders = await _context.ManualOrders.AsNoTracking().ToListAsync();
+            var orders = await _context.ManualOrders
+                .Include(o => o.Items)
+                .AsNoTracking()
+                .ToListAsync();
             return Ok(orders);
         }
 
@@ -40,7 +44,9 @@ namespace Dekofar.API.Controllers
         public async Task<IActionResult> GetById(Guid id)
         {
             // Id'ye göre manuel siparişi arar
-            var order = await _context.ManualOrders.FindAsync(id);
+            var order = await _context.ManualOrders
+                .Include(o => o.Items)
+                .FirstOrDefaultAsync(o => o.Id == id);
             if (order == null)
                 return NotFound(); // Sipariş bulunamazsa 404 döner
 
@@ -65,7 +71,9 @@ namespace Dekofar.API.Controllers
             if (id != order.Id)
                 return BadRequest(); // Id eşleşmezse 400 döner
 
-            var existing = await _context.ManualOrders.FindAsync(id);
+            var existing = await _context.ManualOrders
+                .Include(o => o.Items)
+                .FirstOrDefaultAsync(o => o.Id == id);
             if (existing == null)
                 return NotFound(); // Güncellenecek sipariş yoksa 404 döner
 
@@ -80,11 +88,32 @@ namespace Dekofar.API.Controllers
             existing.PaymentType = order.PaymentType;
             existing.OrderNote = order.OrderNote;
             existing.Status = order.Status;
-            existing.TotalAmount = order.TotalAmount;
             existing.DiscountName = order.DiscountName;
             existing.DiscountType = order.DiscountType;
             existing.DiscountValue = order.DiscountValue;
-            existing.BonusAmount = order.BonusAmount;
+
+            // Update items: remove existing and add new ones
+            _context.ManualOrderItems.RemoveRange(existing.Items);
+            existing.Items.Clear();
+            if (order.Items != null)
+            {
+                foreach (var item in order.Items)
+                {
+                    existing.Items.Add(new ManualOrderItem
+                    {
+                        ProductId = item.ProductId,
+                        ProductName = item.ProductName,
+                        VariantId = item.VariantId,
+                        VariantName = item.VariantName,
+                        Quantity = item.Quantity,
+                        Price = item.Price,
+                        Total = item.Price * item.Quantity
+                    });
+                }
+            }
+
+            existing.TotalAmount = existing.Items.Sum(i => i.Total);
+            existing.BonusAmount = existing.TotalAmount * 0.1m;
 
             await _context.SaveChangesAsync(); // Değişiklikleri kaydeder
             return Ok();


### PR DESCRIPTION
## Summary
- extend manual order items with Shopify variant identifiers
- map variant data through create command and handler
- allow manual order updates to replace item lists and recalculate totals

## Testing
- `dotnet build`
- `dotnet test` *(fails: package 'AutoMapper' not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891995ddc4c8326839a96807c70f410