### PR TITLE
fix: consolidate JWT authentication configuration

### DIFF
--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -9,16 +9,10 @@ using Dekofar.HyperConnect.Infrastructure.Jobs;
 using Dekofar.HyperConnect.Integrations.NetGsm.Interfaces;
 using Dekofar.HyperConnect.Integrations.NetGsm.Services;
 using MediatR;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
-using System.Reflection.Metadata;
-using System.Security.Claims;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
 {
@@ -46,48 +40,7 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             .AddDefaultTokenProviders();
 
 
-            // 🔐 JWT
-            var jwtSettings = configuration.GetSection("Jwt");
-            var key = Encoding.UTF8.GetBytes(jwtSettings["Key"]!);
-
-            services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-            })
-            .AddJwtBearer(options =>
-            {
-                options.RequireHttpsMetadata = false;
-                options.SaveToken = true;
-                options.TokenValidationParameters = new TokenValidationParameters
-                {
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = true,
-                    ValidateIssuerSigningKey = true,
-                    ValidIssuer = jwtSettings["Issuer"],
-                    ValidAudience = jwtSettings["Audience"],
-                    IssuerSigningKey = new SymmetricSecurityKey(key),
-                    ClockSkew = TimeSpan.Zero,
-                    RoleClaimType = ClaimTypes.Role
-                };
-                options.Events = new JwtBearerEvents
-                {
-                    OnMessageReceived = context =>
-                    {
-                        var accessToken = context.Request.Query["access_token"];
-                        var path = context.HttpContext.Request.Path;
-                        if (!string.IsNullOrEmpty(accessToken) &&
-                            (path.StartsWithSegments("/hubs/chat") ||
-                             path.StartsWithSegments("/hubs/notifications") ||
-                             path.StartsWithSegments("/supportHub")))
-                        {
-                            context.Token = accessToken;
-                        }
-                        return Task.CompletedTask;
-                    }
-                };
-            });
+            // JWT authentication is configured in Program.cs to avoid duplicate scheme registration
             services.AddHttpContextAccessor(); // gerekli
             services.AddScoped<ICurrentUserService, CurrentUserService>();
             services.AddScoped<IFileStorageService, LocalFileStorageService>();


### PR DESCRIPTION
## Summary
- consolidate JWT Bearer authentication into a single registration in Program.cs
- remove duplicate authentication setup from infrastructure layer

## Testing
- `dotnet test` *(fails: AutoMapper.dll not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891b438808c83269e03ee7484d99086