### PR TITLE
Fix duplicate JWT bearer registration and HTTPS redirection

### DIFF
--- a/dekofar-hyperconnect-api/Program.cs
+++ b/dekofar-hyperconnect-api/Program.cs
@@ -3,6 +3,7 @@ using System.IdentityModel.Tokens.Jwt;
 using System.Reflection; // Needed for XML comments
 using System.Security.Claims;
 using System.Threading.Tasks;
+using System.Linq; // Needed to safely read Authorization headers
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
@@ -61,24 +62,47 @@ builder.Services.AddAuthentication(options =>
             RoleClaimType = ClaimTypes.Role
         };
 
-        // Allow JWT tokens to be passed via query string for SignalR hubs
+        // Custom token retrieval so that normal HTTP requests read the token from the
+        // Authorization header while SignalR connections can still use the access_token
+        // query string value. Previously overriding OnMessageReceived prevented the
+        // Authorization header from being processed which resulted in 401 responses.
         options.Events = new JwtBearerEvents
         {
             OnMessageReceived = context =>
             {
-                var accessToken = context.Request.Query["access_token"];
-                var path = context.HttpContext.Request.Path;
-                if (!string.IsNullOrEmpty(accessToken) &&
-                    (path.StartsWithSegments("/hubs/chat") ||
-                     path.StartsWithSegments("/hubs/notifications") ||
-                     path.StartsWithSegments("/supportHub")))
+                // 1) Standard HTTP requests: check the Authorization header
+                var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+                if (!string.IsNullOrEmpty(authHeader) &&
+                    authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
                 {
-                    context.Token = accessToken;
+                    context.Token = authHeader.Substring("Bearer ".Length).Trim();
+                }
+
+                // 2) SignalR hubs: allow tokens in the query string for WebSocket clients
+                if (string.IsNullOrEmpty(context.Token))
+                {
+                    var accessToken = context.Request.Query["access_token"];
+                    var path = context.HttpContext.Request.Path;
+                    if (!string.IsNullOrEmpty(accessToken) &&
+                        (path.StartsWithSegments("/hubs/chat") ||
+                         path.StartsWithSegments("/hubs/notifications") ||
+                         path.StartsWithSegments("/supportHub")))
+                    {
+                        context.Token = accessToken;
+                    }
                 }
                 return Task.CompletedTask;
             }
         };
     });
+
+// Explicitly tell the HTTPS redirection middleware which port to use. Azure App Service
+// runs behind a proxy and without this the middleware logs "Failed to determine the https
+// port for redirect".
+builder.Services.AddHttpsRedirection(options =>
+{
+    options.HttpsPort = 443;
+});
 
 // 🌐 CORS Politikası
 var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
@@ -219,11 +243,9 @@ if (app.Environment.IsDevelopment() || app.Environment.IsStaging() || app.Enviro
 app.UseRouting();
 app.UseCors(MyAllowSpecificOrigins);
 
-// Azure App Service already handles HTTPS, so avoid redirect warnings there
-if (!app.Environment.IsProduction())
-{
-    app.UseHttpsRedirection();
-}
+// Redirect all HTTP requests to HTTPS. The port was configured earlier so the
+// middleware works correctly even when running behind Azure App Service.
+app.UseHttpsRedirection();
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- configure JWT authentication once and read tokens from `Authorization` header or SignalR query string
- set explicit HTTPS port for redirection in Azure App Service
- always redirect HTTP requests to HTTPS

## Testing
- `dotnet build dekofar-hyperconnect-api.sln -c Release`
- `dotnet test dekofar-hyperconnect-api.sln -c Release` *(fails: AutoMapper dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891c4e6f8d4832684478042bae9cdf8