### PR TITLE
Fix DI registrations and design-time DbContext resolution

### DIFF
--- a/Dekofar.HyperConnect.Infrastructure/Jobs/NoOpRecurringJob.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Jobs/NoOpRecurringJob.cs
@@ -1,0 +1,28 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Dekofar.HyperConnect.Infrastructure.Jobs
+{
+    /// <summary>
+    /// Fallback implementation used when a concrete recurring job is not wired.
+    /// Keeps DI and manual trigger endpoints from failing at startup.
+    /// </summary>
+    public class NoOpRecurringJob : IRecurringJob
+    {
+        private readonly ILogger<NoOpRecurringJob> _logger;
+
+        public NoOpRecurringJob(ILogger<NoOpRecurringJob> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task RunAsync(CancellationToken cancellationToken = default)
+        {
+            _logger.LogWarning(
+                "IRecurringJob is not configured with a concrete implementation. " +
+                "No operation was performed.");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Dekofar.HyperConnect.Infrastructure/Persistence/DesignTimeDbContextFactory.cs
+++ b/Dekofar.HyperConnect.Infrastructure/Persistence/DesignTimeDbContextFactory.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
 
 namespace Dekofar.HyperConnect.Infrastructure.Persistence
 {
@@ -14,6 +16,7 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
                 ?? "Development";
 
             var basePath = Directory.GetCurrentDirectory();
+            basePath = ResolveBasePath(basePath);
 
             Console.WriteLine($"📁 BasePath: {basePath}");
             Console.WriteLine($"🌍 Environment: {environment}");
@@ -38,6 +41,33 @@ namespace Dekofar.HyperConnect.Infrastructure.Persistence
             optionsBuilder.UseNpgsql(connectionString);
 
             return new ApplicationDbContext(optionsBuilder.Options);
+        }
+
+        private static string ResolveBasePath(string basePath)
+        {
+            var appSettingsPath = Path.Combine(basePath, "appsettings.json");
+            if (File.Exists(appSettingsPath))
+            {
+                return basePath;
+            }
+
+            var apiPath = Path.Combine(basePath, "dekofar-hyperconnect-api");
+            if (File.Exists(Path.Combine(apiPath, "appsettings.json")))
+            {
+                return apiPath;
+            }
+
+            var parent = Directory.GetParent(basePath);
+            if (parent != null)
+            {
+                var parentApiPath = Path.Combine(parent.FullName, "dekofar-hyperconnect-api");
+                if (File.Exists(Path.Combine(parentApiPath, "appsettings.json")))
+                {
+                    return parentApiPath;
+                }
+            }
+
+            return basePath;
         }
     }
 }

--- a/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
+++ b/Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs
@@ -106,8 +106,10 @@ namespace Dekofar.HyperConnect.Infrastructure.ServiceRegistration
             services.AddScoped<IUserNotificationService, UserNotificationService>();
             services.AddScoped<IBadgeService, BadgeService>();
             services.AddScoped<IWorkSessionService, WorkSessionService>();
+            services.AddScoped<IJobStatsService, JobStatsService>();
             services.AddScoped(typeof(IRepository<>), typeof(GenericRepository<>));
             services.AddScoped<IAllowedAdminIpService, AllowedAdminIpService>();
+            services.AddScoped<IRecurringJob, NoOpRecurringJob>();
 
             // =====================================================
             // 📲 NetGSM


### PR DESCRIPTION
### Motivation
- Prevent runtime startup failures caused by missing DI registrations required by controllers and services.
- Ensure EF Core design-time DbContext can locate `appsettings.json` when running migrations from different working directories.
- Provide a safe fallback for recurring-job execution so manual trigger endpoints resolve even if a concrete job is not wired.

### Description
- Registered `IJobStatsService` to resolve `JobStatsService` in the infrastructure DI container so controllers that request `IJobStatsService` via `[FromServices]` will not fail at runtime. (Updated `Dekofar.HyperConnect.Infrastructure/ServiceRegistration/DependencyInjection.cs`)
- Added a no-op fallback implementation `NoOpRecurringJob` that implements `IRecurringJob` and logs a warning when run, and registered it in DI as the default `IRecurringJob` so endpoints depending on `IRecurringJob` can be invoked safely. (Added `Dekofar.HyperConnect.Infrastructure/Jobs/NoOpRecurringJob.cs` and registered in `DependencyInjection.cs`)
- Made the design-time DbContext factory more robust by adding a `ResolveBasePath` helper that searches the current directory, an API subfolder (`dekofar-hyperconnect-api`), and the parent folder for `appsettings.json` before building configuration; also added necessary `using` directives. This allows EF Core tooling and migrations to find the configuration when invoked from different folders. (Updated `Dekofar.HyperConnect.Infrastructure/Persistence/DesignTimeDbContextFactory.cs`)

### Testing
- Attempted to run `dotnet build dekofar-hyperconnect-api.sln` but the environment lacks the `dotnet` CLI, so compile/run tests could not be executed (failed due to missing `dotnet`).
- Verified repository changes via static inspection and local file searches (`rg`/`sed`) to confirm registrations and new file existence; no automated unit/integration tests were executed because the .NET toolchain was unavailable.
- Committed the changes to the repository (`Fix DI and design-time DbContext issues`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697898713028833383bc51377236e15b)